### PR TITLE
IPS-493: Update post-merge workflow to use devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -36,11 +36,15 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
       - name: "Push image and template"
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.5
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
         with:
           artifact-bucket-name: ${{ secrets.BUILD_ARTIFACT_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
           template-file: deploy/template.yaml
+          docker-build-path: .
           role-to-assume-arn: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.BUILD_ECR_NAME_FRONT }}

--- a/.github/workflows/pre-merge-to-dev.yml
+++ b/.github/workflows/pre-merge-to-dev.yml
@@ -36,11 +36,15 @@ jobs:
           username: khw46367
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+
       - name: "Push image and template"
-        uses: govuk-one-login/devplatform-upload-action-ecr@1.0.5
+        uses: govuk-one-login/devplatform-upload-action-ecr@1.2.0
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME }}
           container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
           template-file: deploy/template.yaml
+          docker-build-path: .
           role-to-assume-arn: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.DEV_ECR_NAME_FRONT }}

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# OS generated files
+**/.DS_Store


### PR DESCRIPTION
### What changed

- Updated post-merge workflow to use devplatform-upload-action-ecr@1.2.0
- Updated .gitignore

### Why did it change

- Required for canary deployments across Identity

### Issue tracking
- [IPS-493](https://govukverify.atlassian.net/browse/IPS-493)
- [IPS-532](https://govukverify.atlassian.net/browse/IPS-532)

## Checklists

### Evidence
- Image successfully pushed to dev, with commit tag:
https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/actions/runs/7930584278

![Screenshot 2024-02-16 at 14 58 14](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/153090281/04b3d165-05eb-4405-99c9-300103ea0034)

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-493]: https://govukverify.atlassian.net/browse/IPS-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-532]: https://govukverify.atlassian.net/browse/IPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ