### PR TITLE
PYIC-5161: set up url path routing for question pages

### DIFF
--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -7,6 +7,10 @@ const {
   },
 } = require("../../../lib/config");
 
+const questionKeyToPathMap = new Map([
+  ["rti-payslip-national-insurance", "enter-national-insurance-payslip"],
+]);
+
 class LoadQuestionController extends BaseController {
   async saveValues(req, res, next) {
     super.saveValues(req, res, async () => {
@@ -27,10 +31,14 @@ class LoadQuestionController extends BaseController {
     });
   }
 
-  isSingleAmountQuestion(req) {
-    return (
-      req.session?.question?.questionKey === "rti-payslip-national-insurance"
-    );
+  hasQuestion(req) {
+    return !!req.session?.question;
+  }
+
+  getQuestionPath(req) {
+    return `question/${questionKeyToPathMap.get(
+      req.session?.question?.questionKey
+    )}`;
   }
 }
 module.exports = LoadQuestionController;

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -1,4 +1,5 @@
 const debug = require("debug")("load-question");
+const path = require("path");
 const BaseController = require("hmpo-form-wizard").Controller;
 const presenters = require("../../../presenters");
 
@@ -10,7 +11,10 @@ const {
 
 class SingleAmountQuestionController extends BaseController {
   configure(req, res, next) {
-    req.form.options.template = `${req.form.options.templatePath}/single-amount-question`;
+    req.form.options.template = path.join(
+      req.form.options.templatePath,
+      "single-amount-question"
+    );
     super.configure(req, res, next);
   }
 

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -9,6 +9,11 @@ const {
 } = require("../../../lib/config");
 
 class SingleAmountQuestionController extends BaseController {
+  configure(req, res, next) {
+    req.form.options.template = `${req.form.options.templatePath}/single-amount-question`;
+    super.configure(req, res, next);
+  }
+
   locals(req, res, callback) {
     super.locals(req, res, (err, locals) => {
       if (err) {
@@ -75,14 +80,6 @@ class SingleAmountQuestionController extends BaseController {
 
       callback();
     });
-  }
-
-  next(req) {
-    if (req.session.question) {
-      return "single-amount-question";
-    }
-
-    return "done";
   }
 }
 module.exports = SingleAmountQuestionController;

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -16,13 +16,13 @@ module.exports = {
     skip: true,
     next: [
       {
-        fn: loadQuestionController.prototype.isSingleAmountQuestion,
-        next: "single-amount-question",
+        fn: loadQuestionController.prototype.hasQuestion,
+        next: loadQuestionController.prototype.getQuestionPath,
       },
       "done",
     ],
   },
-  "/single-amount-question": {
+  "/question/enter-national-insurance-payslip": {
     controller: singleAmountQuestionController,
     next: "load-question",
   },

--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -2,12 +2,12 @@ Feature: Happy path
 
   Successful journey through the system and back to the RP
 
-  @mock-api:single-question @single-amount
+  @mock-api:single-question @single-amount-question
   Scenario: Happy Path for single-amount-question
     Given Happy Harriet is using the system
     And they have started the journey
     Then they should see the answer security questions page
     When they continue from answer security questions
-    Then they should see the single-amount-question page
-    When they enter amount and continue from single-amount-question page
+    Then they should see the question page
+    When they enter amount and continue from the question page
     Then they should be redirected as a success

--- a/tests/browser/pages/enter-ni-payslip.js
+++ b/tests/browser/pages/enter-ni-payslip.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/";
+    this.path = "/kbv/question/enter-national-insurance-payslip";
   }
 
   async continue() {
@@ -17,6 +17,6 @@ module.exports = class PlaywrightDevPage {
 
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
-    return pathname.includes(this.path);
+    return pathname === this.path;
   }
 };

--- a/tests/browser/pages/index.js
+++ b/tests/browser/pages/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   AnswerSecurityQuestionsPage: require("./answer-security-questions.js"),
-  SingleAmountQuestionPage: require("./single-amount-question.js"),
+  EnterNIPayslipPage: require("./enter-ni-payslip.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),
 };

--- a/tests/browser/pages/single-amount-question.js
+++ b/tests/browser/pages/single-amount-question.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/single-amount-question";
+    this.path = "/kbv/question/";
   }
 
   async continue() {
@@ -17,6 +17,6 @@ module.exports = class PlaywrightDevPage {
 
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
-    return pathname === this.path;
+    return pathname.includes(this.path);
   }
 };

--- a/tests/browser/step_definitions/enter-ni-payslip.js
+++ b/tests/browser/step_definitions/enter-ni-payslip.js
@@ -1,0 +1,18 @@
+const { Then, When } = require("@cucumber/cucumber");
+const { EnterNIPayslipPage } = require("../pages");
+const { expect } = require("chai");
+
+Then("they should see the question page", async function () {
+  const singleAmountQuestionPage = new EnterNIPayslipPage(this.page);
+
+  expect(singleAmountQuestionPage.isCurrentPage()).to.be.true;
+});
+
+When(
+  "they enter amount and continue from the question page",
+  async function () {
+    const singleAmountQuestionPage = new EnterNIPayslipPage(this.page);
+    await singleAmountQuestionPage.answer();
+    await singleAmountQuestionPage.continue();
+  }
+);

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -133,6 +133,28 @@ resources:
           "redirect_uri": "http://example.net"
         }
 
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "authorization-error"
+    response:
+      statusCode: 202
+
+  - method: GET
+    path: /authorization
+    requestHeaders:
+      session-id: "authorization-error"
+    response:
+      statusCode: 500
+      content: |
+        {
+          "redirect_uri": "http://example.net",
+          "oauth_error": {
+            "error_description": "gateway",
+            "error": "server_error"
+          }
+        }
+
   ### 'session-400' journey ###
   - method: POST
     path: /session
@@ -156,18 +178,3 @@ resources:
       template: true
       content: |
         {}
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "authorization-error"
-    response:
-      statusCode: 500
-      content: |
-        {
-          "redirect_uri": "http://example.net",
-          "oauth_error": {
-            "error_description": "gateway",
-            "error": "server_error"
-          }
-        }

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -138,7 +138,7 @@ resources:
     requestHeaders:
       session-id: "authorization-error"
     response:
-      statusCode: 202
+      statusCode: 204
 
   - method: GET
     path: /authorization

--- a/tests/unit/src/app/kbv/controllers/load-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/load-question.test.js
@@ -64,7 +64,7 @@ describe("question controller", () => {
     });
   });
 
-  describe("#isSingleAmountQuestion", () => {
+  describe("#hasQuestion", () => {
     it('should return "true" when there is a next question', () => {
       const req = {
         session: {
@@ -72,9 +72,9 @@ describe("question controller", () => {
         },
       };
 
-      const route = controller.isSingleAmountQuestion(req);
+      const result = controller.hasQuestion(req);
 
-      expect(route).toBe(true);
+      expect(result).toBe(true);
     });
 
     it('should return "false" when no question', () => {
@@ -83,9 +83,23 @@ describe("question controller", () => {
           question: null,
         },
       };
-      const route = controller.isSingleAmountQuestion(req);
+      const result = controller.hasQuestion(req);
 
-      expect(route).toBe(false);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("#getQuestionPath", () => {
+    it("should return path for the next question", () => {
+      const req = {
+        session: {
+          question: { questionKey: "rti-payslip-national-insurance" },
+        },
+      };
+
+      const result = controller.getQuestionPath(req);
+
+      expect(result).toBe("question/enter-national-insurance-payslip");
     });
   });
 });

--- a/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
@@ -22,6 +22,7 @@ describe("single-amount-question controller", () => {
     req.lang = "en";
     req.form.options = {
       fields: {},
+      templatePath: "template-path",
     };
     req.session.question = {
       questionKey: "Q1",

--- a/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
@@ -37,6 +37,13 @@ describe("single-amount-question controller", () => {
     expect(controller).toBeInstanceOf(BaseController);
   });
 
+  describe("#configure", () => {
+    it("should set the template to be the shared template for this controller", () => {
+      controller.configure(req, res, next);
+      expect(req.form.options.template).toContain("single-amount-question");
+    });
+  });
+
   describe("#locals", () => {
     beforeEach(() => {
       req.session = {
@@ -185,23 +192,6 @@ describe("single-amount-question controller", () => {
 
         await controller.saveValues(req, res, callback);
       });
-    });
-  });
-
-  describe("#next", () => {
-    it('should route to "single-amount-question" with a question', () => {
-      req.session.question = {};
-
-      const route = controller.next(req);
-
-      expect(route).toBe("single-amount-question");
-    });
-
-    it('should route to "done" with no question', () => {
-      req.session.question = undefined;
-      const route = controller.next(req);
-
-      expect(route).toBe("done");
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

### What changed

Set up ability to define routes for each question page, sharing the same underlying controller/template.

### Why did it change

A UCD requirement is that we serve each question page under a distinct url path (as provided by them) - we need a mechanism for defining routes for each question page while sharing a single controller/template and mapping question keys to url paths.

### Issue tracking

- [PYIC-5161](https://govukverify.atlassian.net/browse/PYIC-5161)


[PYIC-5161]: https://govukverify.atlassian.net/browse/PYIC-5161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ