### PR TITLE
PYIC-5255: update HMPO to lagest version, use prefix and month dynamically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.4.0",
+        "hmpo-components": "6.5.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -4044,9 +4044,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
-      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
+      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.4.0",
+    "hmpo-components": "6.5.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -28,6 +28,7 @@ class SingleAmountQuestionController extends BaseController {
           req.lang
         ),
         title: presenters.questionToTitle(req.session.question, req.translate),
+        prefix: "£",
       };
 
       callback(null, locals);

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -27,6 +27,9 @@
       hint: {
         text: question.hint
       },
+      prefix: {
+        text: question.prefix
+      },
       classes: "govuk-input--width-5"
     }) }}
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- update HMPO to lagest version, use prefix and month dynamically

### What changed

- updated HMPO to lagest version
- use prefix and month dynamically

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To support prefix for hmpo input compoenent

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5255](https://govukverify.atlassian.net/browse/PYIC-5255)


[PYIC-5255]: https://govukverify.atlassian.net/browse/PYIC-5255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ