### PR TITLE
PYIC-5211: use dynamic month for the inset texts

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -21,6 +21,7 @@ answer-security-questions:
       <p>Os hoffech wybod mwy am sut y bydd eich manylion yn cael eu defnyddio i brofi eich hunaniaeth,
       <a href='https://signin.account.gov.uk/privacy-notice' class='govuk-link' rel='noreferrer noopener' target='_blank'>
       darllenwch ein hysbysiad preifatrwydd (agor mewn tab newydd)</a>.</p>
+  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Rwyf angen profi fy hunaniaeth mewn ffordd arall</a>"
   start-button: Dechrau
 rti-payslip-national-insurance:
   title: Rhowch swm yr Yswiriant Gwladol a dalwyd gennych o slip cyflog diweddar

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -21,6 +21,7 @@ answer-security-questions:
       <p>If you'd like to know more about how your details will be used to prove your identity,
       <a href='https://signin.account.gov.uk/privacy-notice' class='govuk-link' rel='noreferrer noopener' target='_blank'>
       read our privacy notice (opens in a new tab)</a>.</p>
+  abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>I need to prove my identity another way</a>"
   start-button: Start
 rti-payslip-national-insurance:
   title: Enter the amount of National Insurance you paid from a recent payslip

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -8,7 +8,7 @@ module.exports = function (question, translate, language) {
     const dynamicDate = moment()
       .subtract(question.info.months, "months")
       .locale(language)
-      .format("DD MMMM YYYY");
+      .format("D MMMM YYYY");
     data.dynamicDate = dynamicDate;
   }
 

--- a/src/views/kbv/answer-security-questions.njk
+++ b/src/views/kbv/answer-security-questions.njk
@@ -11,5 +11,5 @@
 
 {% block submitButton %}
   {{ hmpoSubmit(ctx, {id: "start", text: translate("pages.answer-security-questions.start-button")}) }}
-  <p>{{ hmpoHtml(translate("pages.shared.abandon")) }}</p>
+  <p>{{ hmpoHtml(translate("pages.answer-security-questions.abandon")) }}</p>
 {% endblock %}

--- a/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
@@ -42,7 +42,7 @@ describe("single-amount-question controller", () => {
       req.session = {
         question: {
           info: {
-            months: 3,
+            months: "3",
           },
         },
       };

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -1,68 +1,31 @@
 const presenters = require("../../../../src/presenters");
-const moment = require("moment");
+
+Date.now = jest.fn(() => new Date("2024-05-01"));
 
 describe("question-to-inset", () => {
   let translate;
   let question;
   let data;
-  const language = "en";
+  const englishLanguage = "en";
+  const welshLanguage = "cy";
+  const welshDate = "1 Chwefror 2024";
+  const englishDate = "1 February 2024";
 
   beforeEach(() => {
     question = {
       questionKey: "rti-payslip-national-insurance",
       info: {
-        months: 3,
+        months: "3",
       },
     };
-    data = {
-      dynamicDate: moment()
-        .subtract(question.info.months, "months")
-        .locale(language)
-        .format("DD MMMM YYYY"),
-    };
+    data = { dynamicDate: englishDate };
 
     translate = jest.fn();
   });
 
-  it("should call translate using questionID and months", () => {
-    presenters.questionToInset(question, translate, language);
-
-    expect(translate).toHaveBeenCalledWith(
-      "fields.rti-payslip-national-insurance.inset",
-      data
-    );
-  });
-
-  it("should call translate using questionID and 12 months", () => {
-    question.info.months = 12;
-    data = {
-      dynamicDate: moment()
-        .subtract(question.info.months, "months")
-        .locale(language)
-        .format("DD MMMM YYYY"),
-    };
-
-    presenters.questionToInset(question, translate, language);
-
-    expect(translate).toHaveBeenCalledWith(
-      "fields.rti-payslip-national-insurance.inset",
-      data
-    );
-  });
-
-  it("should call translate using questionID without month when month is 0", () => {
-    question.info.months = 0;
-    presenters.questionToInset(question, translate, language);
-
-    expect(translate).toHaveBeenCalledWith(
-      "fields.rti-payslip-national-insurance.inset",
-      {}
-    );
-  });
-
-  it("should call translate using questionID", () => {
+  it("should call translate using questionID without month when month is undefined", () => {
     question.info.months = undefined;
-    presenters.questionToInset(question, translate, language);
+    presenters.questionToInset(question, translate, englishLanguage);
 
     expect(translate).toHaveBeenCalledWith(
       "fields.rti-payslip-national-insurance.inset",
@@ -70,16 +33,59 @@ describe("question-to-inset", () => {
     );
   });
 
-  describe("with found key", () => {
-    it("should return translated inset when found", () => {
+  it("should return empty string when translation not present", () => {
+    translate.mockReturnValue(undefined);
+    const insetTest = presenters.questionToInset(
+      question,
+      translate,
+      englishLanguage
+    );
+
+    expect(insetTest).toBe(" ");
+  });
+
+  describe("with tranlation key found", () => {
+    it("should return english language translated content", () => {
       translate.mockReturnValue(
-        `translated question inset three months ago ${data.dynamicDate}`
+        `translated question inset three months ago ${englishDate}`
       );
 
-      const result = presenters.questionToInset(question, translate, language);
+      const result = presenters.questionToInset(
+        question,
+        translate,
+        englishLanguage
+      );
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        data
+      );
 
       expect(result).toBe(
-        `translated question inset three months ago ${data.dynamicDate}`
+        `translated question inset three months ago ${englishDate}`
+      );
+    });
+
+    it("should return welsh language translated content", () => {
+      translate.mockReturnValue(
+        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
+      );
+
+      const result = presenters.questionToInset(
+        question,
+        translate,
+        welshLanguage
+      );
+
+      data.dynamicDate = welshDate;
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        data
+      );
+
+      expect(result).toBe(
+        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
       );
     });
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- use dynamic month for the inset texts

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- To pass month dynamically to inset text

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5211](https://govukverify.atlassian.net/browse/PYIC-5211)


[PYIC-5211]: https://govukverify.atlassian.net/browse/PYIC-5211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ