### PR TITLE
PYIC-4652: Add Tax credits question page

### DIFF
--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -10,6 +10,7 @@ const {
 const questionKeyToPathMap = new Map([
   ["rti-payslip-national-insurance", "enter-national-insurance-payslip"],
   ["rti-payslip-income-tax", "enter-tax-payslip"],
+  ["ita-bankaccount", "enter-4-digits-bank-account-tax-credits"],
 ]);
 
 class LoadQuestionController extends BaseController {

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -30,6 +30,10 @@ module.exports = {
     controller: singleAmountQuestionController,
     next: "load-question",
   },
+  "/question/enter-4-digits-bank-account-tax-credits": {
+    controller: singleAmountQuestionController,
+    next: "load-question",
+  },
   "/done": {
     skip: true,
     noPost: true,

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -4,3 +4,6 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Swm
   hint: Er enghraifft, 123.86
+ita-bankaccount:
+  label: 4 digid olaf o rif eich cyfrif
+  hint: ""

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -36,3 +36,11 @@ rti-payslip-income-tax:
     - Dywedwch wrthym faint o Dreth Incwm rydych wedi'i dalu.
     - Fel arfer, gallwch ddod o hyd i'r swm wrth ymyl unrhyw bensiynau neu daliadau Yswiriant Gwladol ar eich slip cyflog. Gallai gael ei alw'n TWE neu'n Dreth Incwm
     - Rhowch y swm mewn punnoedd a cheiniogau yn union fel y mae'n ymddangos ar eich slip cyflog.
+ita-bankaccount:
+  title: Rhowch 4 digid olaf y cyfrif banc neu gymdeithas adeiladu y telir eich credydau treth iddo
+  content:
+    - Gallwch chwilio am eich rhif cyfrif ar eich
+    - - cerdyn banc
+      - cyfrif ar-lein neu ap bancio
+      - cyfriflen banc
+      - llyfr talu i mewn neu lyfr siec

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -4,3 +4,6 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Amount
   hint: For example 123.86
+ita-bankaccount:
+  label: Last 4 digits of your account number
+  hint: ""

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -36,3 +36,11 @@ rti-payslip-income-tax:
     - Tell us the amount of Income Tax you paid.
     - You can usually find the amount next to any pensions or National Insurance payments on your payslip. It may be called PAYE/Income Tax.
     - Enter the amount in pounds and pence, exactly as it appears on your payslip.
+ita-bankaccount:
+  title: Enter the last 4 digits of the bank or building society account your tax credits are paid into
+  content:
+    - "You can look for your account number on your:"
+    - - bank card
+      - online account or banking app
+      - bank statement
+      - paying-in book or cheque book

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -9,9 +9,11 @@
 {% block mainContent %}
   <h1 class="govuk-heading-l"> {{ question.title }} </h1>
 
-  {{ govukInsetText({
-    text: question.inset
-  }) }}
+  {% if question.inset != " " %}
+    {{ govukInsetText({
+      text: question.inset
+    }) }}
+  {% endif %}
 
   {{ hmpoHtml(question.content) }}
 

--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -13,3 +13,13 @@ Feature: Happy path
     Then they should see the Enter Tax Payslip question page
     When they enter amount and continue from the Enter Tax Payslip question page
     Then they should be redirected as a success
+
+  @mock-api:taxCredits @taxCredits-journey
+  Scenario: Happy Path for taxCredits-journey
+    Given Happy Harriet is using the system
+    And they have started the journey
+    Then they should see the answer security questions page
+    When they continue from answer security questions
+    Then they should see the enter-4-digits-bank-account-tax-credits question page
+    When they enter amount and continue from the enter-4-digits-bank-account-tax-credits question page
+    Then they should be redirected as a success

--- a/tests/browser/pages/enter-4-digits-bank-account-tax-credits.js
+++ b/tests/browser/pages/enter-4-digits-bank-account-tax-credits.js
@@ -1,0 +1,22 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/kbv/question/enter-4-digits-bank-account-tax-credits";
+  }
+
+  async continue() {
+    await this.page.click("#continue");
+  }
+
+  async answer() {
+    await this.page.fill('input[type="text"]', "23");
+  }
+
+  isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+    return pathname === this.path;
+  }
+};

--- a/tests/browser/pages/index.js
+++ b/tests/browser/pages/index.js
@@ -2,6 +2,7 @@ module.exports = {
   AnswerSecurityQuestionsPage: require("./answer-security-questions.js"),
   EnterNIPayslipPage: require("./enter-ni-payslip.js"),
   EnterTaxPayslipPage: require("./enter-tax-payslip.js"),
+  Enter4DigitsBankAccountTaxCredits: require("./enter-4-digits-bank-account-tax-credits.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),
 };

--- a/tests/browser/step_definitions/enter-4-digits-bank-account-tax-credits.js
+++ b/tests/browser/step_definitions/enter-4-digits-bank-account-tax-credits.js
@@ -1,0 +1,25 @@
+const { Then, When } = require("@cucumber/cucumber");
+const { Enter4DigitsBankAccountTaxCredits } = require("../pages");
+const { expect } = require("chai");
+
+Then(
+  "they should see the enter-4-digits-bank-account-tax-credits question page",
+  async function () {
+    const singleAmountQuestionPage = new Enter4DigitsBankAccountTaxCredits(
+      this.page
+    );
+
+    expect(singleAmountQuestionPage.isCurrentPage()).to.be.true;
+  }
+);
+
+When(
+  "they enter amount and continue from the enter-4-digits-bank-account-tax-credits question page",
+  async function () {
+    const singleAmountQuestionPage = new Enter4DigitsBankAccountTaxCredits(
+      this.page
+    );
+    await singleAmountQuestionPage.answer();
+    await singleAmountQuestionPage.continue();
+  }
+);

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -13,6 +13,11 @@
           "months": "3"
         }
       }
+    ],
+    "taxCredits": [
+      {
+        "questionKey": "ita-bankaccount"
+      }
     ]
   }
 }

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -58,6 +58,50 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
+  ### "taxCredits" journey ###
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "taxCredits"
+    response:
+      scriptFile: scripts/get-question.groovy
+
+  - method: GET
+    path: /authorization
+    requestHeaders:
+      session-id: "taxCredits"
+    response:
+      template: true
+      statusCode: 200
+      content: |
+        {
+          "authorizationCode": {
+            "value":"auth-code-${random.uuid()}"
+          },
+          "state":"sT@t3",
+          "redirect_uri":"http://example.net"
+        }
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+      value: "taxCredits"
+    response:
+      statusCode: 201
+      template: true
+      content: |
+        {
+          "session_id": "taxCredits",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+  - method: POST
+    path: /answer
+    requestHeaders:
+      session-id: "taxCredits"
+    response:
+      scriptFile: scripts/post-answer.groovy
+
   ### 'insufficient-questions' journey ###
   - method: GET
     path: /question


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

URL path: /enter-4-digits-bank-account-tax-credits
Question key: ita-bankaccount

Create the page, add context along with welsh translations Added to the question key map and grouped with singleAmountQuestion Added steps to create the happy path browser test for bankAccount questions

<img width="500" alt="Screenshot 2024-03-20 at 14 48 31" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/1f0089ef-0f99-4d50-b0f8-7b46a460ad57">

(when [hmpo-components PR](https://github.com/HMPO/hmpo-components/pull/165) gets merged the prefix will be an optional field. There is a separate PR to [downgrade hmpo-components](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/pull/116) for now which will revert this to a plain text input field)

### Why did it change

Users need to be able to enter last 4 digits from a particular bank account in order for HMRC to validate that user is who they say they are.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4652](https://govukverify.atlassian.net/browse/PYIC-4652)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-4652]: https://govukverify.atlassian.net/browse/PYIC-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ