### PR TITLE
PYIC-4652: Downgrade hmpo-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.5.0",
+        "hmpo-components": "6.4.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
-      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
+      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.5.0",
+    "hmpo-components": "6.4.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We are temporarily downgrading hmpo-components

It was decided that for now and to unblock our tickets that we revert to an earlier version of hmpo-components and just use the plain text input field until the above PR gets merged.

### Why did it change

We made a change in hmpo-components to add the prefix field to the text inputs, however this change made it a required field and therefore cant use the input field without a prefix There is a current PR https://github.com/HMPO/hmpo-components/pull/165 to fix this issue which is awaiting merge from HMPO

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4652](https://govukverify.atlassian.net/browse/PYIC-4652)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[PYIC-4652]: https://govukverify.atlassian.net/browse/PYIC-4652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ