### PR TITLE
PYIC-4670: Add P60 question page - Total for year amount

### DIFF
--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -11,6 +11,7 @@ const questionKeyToPathMap = new Map([
   ["rti-payslip-national-insurance", "enter-national-insurance-payslip"],
   ["rti-payslip-income-tax", "enter-tax-payslip"],
   ["ita-bankaccount", "enter-4-digits-bank-account-tax-credits"],
+  ["rti-p60-payment-for-year", "enter-total-for-year-p60"],
 ]);
 
 class LoadQuestionController extends BaseController {

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -36,6 +36,11 @@ class SingleAmountQuestionController extends BaseController {
           req.translate,
           req.lang
         ),
+        details: presenters.questionToDetails(
+          req.session.question,
+          req.translate,
+          req.lang
+        ),
         title: presenters.questionToTitle(req.session.question, req.translate),
         prefix: "£",
         name: req.session.question?.questionKey,

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -34,6 +34,10 @@ module.exports = {
     controller: singleAmountQuestionController,
     next: "load-question",
   },
+  "/question/enter-total-for-year-p60": {
+    controller: singleAmountQuestionController,
+    next: "load-question",
+  },
   "/question/enter-4-digits-bank-account-tax-credits": {
     backLink: null,
     fields: ["ita-bankaccount"],

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -4,6 +4,9 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Swm
   hint: Er enghraifft, 123.86
+rti-p60-payment-for-year:
+  label: Swm
+  hint: Er enghraifft, 21350.75
 ita-bankaccount:
   label: 4 digid olaf o rif eich cyfrif
   hint: ""

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -36,6 +36,17 @@ rti-payslip-income-tax:
     - Dywedwch wrthym faint o Dreth Incwm rydych wedi'i dalu.
     - Fel arfer, gallwch ddod o hyd i'r swm wrth ymyl unrhyw bensiynau neu daliadau Yswiriant Gwladol ar eich slip cyflog. Gallai gael ei alw'n TWE neu'n Dreth Incwm
     - Rhowch y swm mewn punnoedd a cheiniogau yn union fel y mae'n ymddangos ar eich slip cyflog.
+rti-p60-payment-for-year:
+  title: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
+  inset: Defnyddiwch P60 o'r flwyddyn dreth {{ dynamicDate }} i ateb y cwestiwn hwn.
+  content:
+    - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘cyfanswm am y flwyddyn’. Byddwch yn dod o hyd i hyn yn yr adran ‘manylion cyflog a threth incwm’ o'ch P60.
+    - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
+  details:
+    summaryText: Os oes gennych fwy nag un P60
+    html: >-
+      <p>Rhowch y swm yn y blwch wedi'i labelu ‘yn y gyflogaeth hon’.</p>
+      <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi. </p>
 ita-bankaccount:
   title: Rhowch 4 digid olaf y cyfrif banc neu gymdeithas adeiladu y telir eich credydau treth iddo
   content:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -38,7 +38,7 @@ rti-payslip-income-tax:
     - Rhowch y swm mewn punnoedd a cheiniogau yn union fel y mae'n ymddangos ar eich slip cyflog.
 rti-p60-payment-for-year:
   title: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
-  inset: Defnyddiwch P60 o'r flwyddyn dreth {{ dynamicDate }} i ateb y cwestiwn hwn.
+  inset: Defnyddiwch P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} i ateb y cwestiwn hwn.
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘cyfanswm am y flwyddyn’. Byddwch yn dod o hyd i hyn yn yr adran ‘manylion cyflog a threth incwm’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -4,6 +4,9 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Amount
   hint: For example 123.86
+rti-p60-payment-for-year:
+  label: Amount
+  hint: For example, 21350.75
 ita-bankaccount:
   label: Last 4 digits of your account number
   hint: ""

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -36,6 +36,17 @@ rti-payslip-income-tax:
     - Tell us the amount of Income Tax you paid.
     - You can usually find the amount next to any pensions or National Insurance payments on your payslip. It may be called PAYE/Income Tax.
     - Enter the amount in pounds and pence, exactly as it appears on your payslip.
+rti-p60-payment-for-year:
+  title: Enter the ‘total for year’ amount from your P60
+  inset: Use a P60 from the tax year {{ dynamicDate }} to answer this question.
+  content:
+    - Tell us the amount in the box labelled ‘total for year’. You’ll find this in the ‘pay and income tax details’ section of your P60.
+    - Enter the amount in pounds and pence, exactly as it appears on your P60.
+  details:
+    summaryText: If you have more than one P60
+    html: >-
+      <p>Enter the amount in the box labelled ‘in this employment’.</p>
+      <p>You only need to enter the amount from one P60.</p>
 ita-bankaccount:
   title: Enter the last 4 digits of the bank or building society account your tax credits are paid into
   content:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -38,7 +38,7 @@ rti-payslip-income-tax:
     - Enter the amount in pounds and pence, exactly as it appears on your payslip.
 rti-p60-payment-for-year:
   title: Enter the ‘total for year’ amount from your P60
-  inset: Use a P60 from the tax year {{ dynamicDate }} to answer this question.
+  inset: Use a P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
   content:
     - Tell us the amount in the box labelled ‘total for year’. You’ll find this in the ‘pay and income tax details’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.

--- a/src/presenters/index.js
+++ b/src/presenters/index.js
@@ -3,6 +3,7 @@ const questionToLabel = require("./question-to-label");
 const questionToContent = require("./question-to-content");
 const questionToInset = require("./question-to-inset");
 const questionToTitle = require("./question-to-title");
+const questionToDetails = require("./question-to-details");
 
 module.exports = {
   questionToHint,
@@ -10,4 +11,5 @@ module.exports = {
   questionToContent,
   questionToInset,
   questionToTitle,
+  questionToDetails,
 };

--- a/src/presenters/question-to-details.js
+++ b/src/presenters/question-to-details.js
@@ -1,0 +1,15 @@
+module.exports = function (question, translate) {
+  const key = `fields.${question.questionKey}.details`;
+  const details = translate(key);
+
+  if (
+    details &&
+    typeof details === "object" &&
+    "summaryText" in details &&
+    "html" in details
+  ) {
+    return details;
+  }
+
+  return " ";
+};

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -1,4 +1,5 @@
 const moment = require("moment");
+const taxYearToRange = require("../utils/tax-year-to-range");
 
 module.exports = function (question, translate, language) {
   const key = `fields.${question.questionKey}.inset`;
@@ -10,6 +11,10 @@ module.exports = function (question, translate, language) {
       .locale(language)
       .format("D MMMM YYYY");
     data.dynamicDate = dynamicDate;
+  }
+
+  if (question?.info?.currentTaxYear) {
+    Object.assign(data, taxYearToRange(question?.info?.currentTaxYear));
   }
 
   const inset = translate(key, data);

--- a/src/utils/tax-year-to-range.js
+++ b/src/utils/tax-year-to-range.js
@@ -1,0 +1,14 @@
+module.exports = function (taxYear) {
+  const data = {};
+
+  if (taxYear) {
+    const [startYear] = taxYear.split("/");
+    const yearRangeStart = parseInt(startYear, 10);
+    const yearRangeEnd = yearRangeStart + 1;
+
+    data.yearRangeStart = yearRangeStart;
+    data.yearRangeEnd = yearRangeEnd;
+  }
+
+  return data;
+};

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -1,6 +1,8 @@
 {% extends "base-form.njk" %}
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "hmpo-details/macro.njk" import hmpoDetails %}
+
 
 {% set gtmJourney = "kbv-hmrc - middle" %}
 
@@ -16,6 +18,13 @@
   {% endif %}
 
   {{ hmpoHtml(question.content) }}
+
+  {% if question.details != " " %}
+    {{ hmpoDetails({
+      summaryText: question.details.summaryText,
+      html: question.details.html
+    }) }}
+  {% endif %}
 
   {% call hmpoForm(ctx) %}
 

--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -12,6 +12,8 @@ Feature: Happy path
     When they enter amount and continue from the Enter NI Payslip question page
     Then they should see the Enter Tax Payslip question page
     When they enter amount and continue from the Enter Tax Payslip question page
+    Then they should see the enter-total-for-year-p60 question page
+    When they enter amount and continue from the enter-total-for-year-p60 question page
     Then they should be redirected as a success
 
   @mock-api:taxCredits @taxCredits-journey

--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -12,9 +12,18 @@ Feature: Happy path
     When they enter amount and continue from the Enter NI Payslip question page
     Then they should see the Enter Tax Payslip question page
     When they enter amount and continue from the Enter Tax Payslip question page
+    Then they should be redirected as a success
+
+  @mock-api:p60 @p60-journey
+  Scenario: Happy Path for p60-journey
+    Given Happy Harriet is using the system
+    And they have started the journey
+    Then they should see the answer security questions page
+    When they continue from answer security questions
     Then they should see the enter-total-for-year-p60 question page
     When they enter amount and continue from the enter-total-for-year-p60 question page
     Then they should be redirected as a success
+
 
   @mock-api:taxCredits @taxCredits-journey
   Scenario: Happy Path for taxCredits-journey

--- a/tests/browser/pages/enter-total-for-year-p60.js
+++ b/tests/browser/pages/enter-total-for-year-p60.js
@@ -1,0 +1,22 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/kbv/question/enter-total-for-year-p60";
+  }
+
+  async continue() {
+    await this.page.click("#continue");
+  }
+
+  async answer() {
+    await this.page.fill('input[type="text"]', "2023");
+  }
+
+  isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+    return pathname === this.path;
+  }
+};

--- a/tests/browser/pages/index.js
+++ b/tests/browser/pages/index.js
@@ -2,6 +2,7 @@ module.exports = {
   AnswerSecurityQuestionsPage: require("./answer-security-questions.js"),
   EnterNIPayslipPage: require("./enter-ni-payslip.js"),
   EnterTaxPayslipPage: require("./enter-tax-payslip.js"),
+  EnterTotalForYearP60Page: require("./enter-total-for-year-p60.js"),
   Enter4DigitsBankAccountTaxCredits: require("./enter-4-digits-bank-account-tax-credits.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),

--- a/tests/browser/step_definitions/enter-total-for-year-p60.js
+++ b/tests/browser/step_definitions/enter-total-for-year-p60.js
@@ -1,0 +1,21 @@
+const { Then, When } = require("@cucumber/cucumber");
+const { EnterTotalForYearP60Page } = require("../pages");
+const { expect } = require("chai");
+
+Then(
+  "they should see the enter-total-for-year-p60 question page",
+  async function () {
+    const singleAmountQuestionPage = new EnterTotalForYearP60Page(this.page);
+
+    expect(singleAmountQuestionPage.isCurrentPage()).to.be.true;
+  }
+);
+
+When(
+  "they enter amount and continue from the enter-total-for-year-p60 question page",
+  async function () {
+    const singleAmountQuestionPage = new EnterTotalForYearP60Page(this.page);
+    await singleAmountQuestionPage.answer();
+    await singleAmountQuestionPage.continue();
+  }
+);

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -12,6 +12,12 @@
         "info": {
           "months": "3"
         }
+      },
+      {
+        "questionKey": "rti-p60-payment-for-year",
+        "info": {
+          "currentTaxYear": "2022/23"
+        }
       }
     ],
     "taxCredits": [

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -12,7 +12,9 @@
         "info": {
           "months": "3"
         }
-      },
+      }
+    ],
+    "p60": [
       {
         "questionKey": "rti-p60-payment-for-year",
         "info": {

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -58,6 +58,52 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
+  ### "p60" journey ###
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "p60"
+    response:
+      scriptFile: scripts/get-question.groovy
+
+  - method: GET
+    path: /authorization
+    requestHeaders:
+      session-id: "p60"
+    response:
+      template: true
+      statusCode: 200
+      content: |
+        {
+          "authorizationCode": {
+            "value":"auth-code-${random.uuid()}"
+          },
+          "state":"sT@t3",
+          "redirect_uri":"http://example.net"
+        }
+
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+      value: "p60"
+    response:
+      statusCode: 201
+      template: true
+      content: |
+        {
+          "session_id": "p60",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+
+  - method: POST
+    path: /answer
+    requestHeaders:
+      session-id: "p60"
+    response:
+      scriptFile: scripts/post-answer.groovy
+
   ### "taxCredits" journey ###
   - method: GET
     path: /question

--- a/tests/unit/src/presenters/question-to-details.test.js
+++ b/tests/unit/src/presenters/question-to-details.test.js
@@ -1,0 +1,58 @@
+const presenters = require("../../../../src/presenters");
+
+describe("question-to-details", () => {
+  let translate;
+  let question;
+
+  beforeEach(() => {
+    question = {
+      questionKey: "rti-payslip-national-insurance",
+    };
+
+    translate = jest.fn();
+  });
+
+  it("should call translate using questionID", () => {
+    presenters.questionToDetails(question, translate);
+
+    expect(translate).toHaveBeenCalledWith(
+      "fields.rti-payslip-national-insurance.details"
+    );
+  });
+
+  describe("with found key", () => {
+    it("should return details when found with expected structure", () => {
+      const mockDetails = {
+        summaryText: "Test summary text",
+        html: "<p>Test HTML content</p>",
+      };
+
+      translate.mockReturnValue(mockDetails);
+
+      const result = presenters.questionToDetails(question, translate);
+
+      expect(result).toEqual(mockDetails);
+    });
+  });
+
+  describe("with missing or invalid key", () => {
+    it("should return an empty string if details are missing", () => {
+      translate.mockReturnValue(undefined);
+
+      const result = presenters.questionToDetails(question, translate);
+
+      expect(result).toBe(" ");
+    });
+
+    it("should return an empty string if details are not in the expected format", () => {
+      translate.mockReturnValue({
+        summaryText: "Test summary text",
+        description: "Invalid property",
+      });
+
+      const result = presenters.questionToDetails(question, translate);
+
+      expect(result).toBe(" ");
+    });
+  });
+});

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -1,4 +1,5 @@
 const presenters = require("../../../../src/presenters");
+const taxYearToRange = require("../../../../src/utils/tax-year-to-range");
 
 Date.now = jest.fn(() => new Date("2024-05-01"));
 
@@ -19,7 +20,6 @@ describe("question-to-inset", () => {
       },
     };
     data = { dynamicDate: englishDate };
-
     translate = jest.fn();
   });
 
@@ -44,7 +44,7 @@ describe("question-to-inset", () => {
     expect(insetTest).toBe(" ");
   });
 
-  describe("with tranlation key found", () => {
+  describe("with translation key found", () => {
     it("should return english language translated content", () => {
       translate.mockReturnValue(
         `translated question inset three months ago ${englishDate}`
@@ -86,6 +86,48 @@ describe("question-to-inset", () => {
 
       expect(result).toBe(
         `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
+      );
+    });
+  });
+
+  describe("question-to-inset with currentTaxYear", () => {
+    let question;
+    const englishLanguage = "en";
+
+    beforeEach(() => {
+      translate = jest.fn();
+    });
+
+    it("should include tax year information in the translated inset when currentTaxYear is defined", () => {
+      question = {
+        questionKey: "rti-payslip-national-insurance",
+        info: {
+          currentTaxYear: "2022/23",
+        },
+      };
+
+      const { yearRangeStart, yearRangeEnd } = taxYearToRange(
+        question?.info?.currentTaxYear
+      );
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        { yearRangeStart, yearRangeEnd }
+      );
+    });
+
+    it("should not include tax year information in the translated inset when currentTaxYear is not defined", () => {
+      question = {
+        questionKey: "rti-payslip-national-insurance",
+        info: {},
+      };
+
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        {}
       );
     });
   });

--- a/tests/unit/src/utils/tax-year-to-range.test.js
+++ b/tests/unit/src/utils/tax-year-to-range.test.js
@@ -1,0 +1,34 @@
+const taxYearToRange = require("../../../../src/utils/tax-year-to-range");
+
+Date.now = jest.fn(() => new Date("2024-05-01"));
+
+describe("tax-year-to-range", () => {
+  let question;
+  const taxYear = "2022/23";
+  const yearRangeStart = 2022;
+  const yearRangeEnd = 2023;
+
+  beforeEach(() => {
+    question = {
+      questionKey: "sa-income-from-pensions",
+      info: {
+        currentTaxYear: taxYear,
+      },
+    };
+  });
+
+  it("should return empty object when currentTaxYear is undefined", () => {
+    question.info.currentTaxYear = undefined;
+    const result = taxYearToRange(question?.info?.currentTaxYear);
+
+    expect(result).toEqual({});
+  });
+
+  describe("with currentTaxYear defined", () => {
+    it("should return object with yearRangeStart and yearRangeEnd when currentTaxYear is defined", () => {
+      const result = taxYearToRange(question?.info?.currentTaxYear);
+
+      expect(result).toEqual({ yearRangeStart, yearRangeEnd });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

URL path: /enter-total-for-year-p60
Question key: rti-p60-payment-for-year

Added content along with welsh translations
Added a new presenter for the details object along with test suite 
Add a new utils file to help translate currentTaxYear to the correct format needed along with test suite
Added to the question key map and grouped with singleAmountQuestion 
Added steps and actions for a new browser test, p60-journey

### Why did it change

Users need to be able to enter details from their P60 so HMRC can validate that the user is who they say they are.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4670](https://govukverify.atlassian.net/browse/PYIC-4670)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[PYIC-4670]: https://govukverify.atlassian.net/browse/PYIC-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ