### PR TITLE
PYIC-4655: Add 'recent tax credits' question page

### DIFF
--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -26,6 +26,7 @@ const questionKeyToPathMap = new Map([
   ["rti-p60-student-loan-deductions", "enter-student-loan-deductions-p60"],
   ["rti-p60-employee-ni-contributions", "enter-employees-contributions-p60"],
   ["sa-income-from-pensions", "what-type-self-assessment"],
+  ["tc-amount", "enter-recent-tax-credits-payment"],
 ]);
 
 class LoadQuestionController extends BaseController {

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -24,7 +24,8 @@ class SingleAmountQuestionController extends BaseController {
         hint: presenters.questionToHint(req.session.question, req.translate),
         content: presenters.questionToContent(
           req.session.question,
-          req.translate
+          req.translate,
+          req.lang
         ),
         inset: presenters.questionToInset(
           req.session.question,

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -81,6 +81,12 @@ module.exports = {
     controller: singleAmountQuestionController,
     next: "load-question",
   },
+  "/question/enter-recent-tax-credits-payment": {
+    backLink: null,
+    fields: ["tc-amount"],
+    controller: singleAmountQuestionController,
+    next: "load-question",
+  },
   "/question/what-type-self-assessment": {
     template: "self-assessment-router",
     backLink: null,

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -118,3 +118,6 @@ statePensionAndBenefitsShort:
   hint: Defnyddiwch blwch 4.6
   prefix: £
   content: ""
+tc-amount:
+  label: Swm
+  hint: Er enghraifft, 36.75

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -152,3 +152,8 @@ pensions-benefits-short-tax-return:
     - Dywedwch wrthym swm y pensiynau a budd-daliadau rydych yn eu derbyn.
     - Mae rhifau'r blychau ac enwau ar y dudalen hon yr un fath ag ar eich ffurflen dreth.
     - Rhowch y symiau mewn punnoedd heb y ceiniog, yn union fel maent yn ymddangos ar eich ffurflen dreth. Os yw'r blwch ar eich ffurflen dreth yn wag, rhowch 0.
+tc-amount:
+  title: Rhowch swm taliad credydau treth diweddar
+  content:
+    - Dywedwch wrthym am daliad credydau treth a gawsoch ar ôl {{ dynamicDate }}.
+    - Byddwch yn cael taliadau credydau treth bob wythnos neu bob 4 wythnos. Dim ond swm un taliad sydd angen i chi ei roi

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -118,3 +118,6 @@ statePensionAndBenefitsShort:
   hint: Use box 4.6
   prefix: £
   content: ""
+tc-amount:
+  label: Amount
+  hint: For example 36.75

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -152,3 +152,8 @@ pensions-benefits-short-tax-return:
     - Tell us the amounts you received in pensions and benefits.
     - The box numbers and names on this page are the same as on your tax return.
     - Enter the amounts in pounds without the pence, exactly as they appear on your tax return. If the box on your tax return is empty, enter 0.
+tc-amount:
+  title: Enter a recent tax credits payment amount
+  content:
+    - Tell us about a tax credits payment you’ve had after {{ dynamicDate }}.
+    - You’ll get tax credits payments every week or every 4 weeks. You only need to enter one payment amount.

--- a/src/presenters/question-to-content.js
+++ b/src/presenters/question-to-content.js
@@ -1,6 +1,14 @@
-module.exports = function (question, translate) {
+const taxCreditsMonths = require("../utils/tax-credits-months");
+
+module.exports = function (question, translate, language) {
   const key = `fields.${question.questionKey}.content`;
-  const content = translate(key);
+  const data = {};
+
+  if (question?.info?.months) {
+    Object.assign(data, taxCreditsMonths(question?.info?.months, language));
+  }
+
+  const content = translate(key, data);
 
   if (content && !content.includes(question.questionKey)) {
     return content;

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -1,16 +1,12 @@
-const moment = require("moment");
 const taxYearToRange = require("../utils/tax-year-to-range");
+const taxCreditsMonths = require("../utils/tax-credits-months");
 
 module.exports = function (question, translate, language) {
   const key = `fields.${question.questionKey}.inset`;
   const data = {};
 
   if (question?.info?.months) {
-    const dynamicDate = moment()
-      .subtract(question.info.months, "months")
-      .locale(language)
-      .format("D MMMM YYYY");
-    data.dynamicDate = dynamicDate;
+    Object.assign(data, taxCreditsMonths(question?.info?.months, language));
   }
 
   if (question?.info?.currentTaxYear) {

--- a/src/utils/tax-credits-months.js
+++ b/src/utils/tax-credits-months.js
@@ -1,0 +1,15 @@
+const moment = require("moment");
+
+module.exports = function (months, language) {
+  const data = {};
+
+  if (months) {
+    const dynamicDate = moment()
+      .subtract(months, "months")
+      .locale(language)
+      .format("D MMMM YYYY");
+    data.dynamicDate = dynamicDate;
+  }
+
+  return data;
+};

--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -74,4 +74,6 @@ Feature: Happy path
     When they enter an invalid account number and continue from the enter-4-digits-bank-account-tax-credits question page
     Then they should see enter correct account number error message
     When they enter correct account number and continue from the enter-4-digits-bank-account-tax-credits question page
+    When they should see the enter-recent-tax-credits-payment question page
+    When they enter correct account number and continue from the enter-recent-tax-credits-payment question page
     Then they should be redirected as a success

--- a/tests/browser/pages/enter-recent-tax-credits-payment.js
+++ b/tests/browser/pages/enter-recent-tax-credits-payment.js
@@ -1,0 +1,26 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+    this.path = "/kbv/question/enter-recent-tax-credits-payment";
+  }
+
+  async continue() {
+    await this.page.click("#continue");
+  }
+
+  async answer(answer) {
+    await this.page.fill('input[type="text"]', answer);
+  }
+
+  isCurrentPage() {
+    const { pathname } = new URL(this.page.url());
+    return pathname === this.path;
+  }
+
+  hasErrorSummary() {
+    return this.page.locator(".govuk-error-summary");
+  }
+};

--- a/tests/browser/pages/index.js
+++ b/tests/browser/pages/index.js
@@ -4,6 +4,7 @@ module.exports = {
   EnterTaxPayslipPage: require("./enter-tax-payslip.js"),
   AnswerP60QuestionsPage: require("./answer-p60-questions.js"),
   Enter4DigitsBankAccountTaxCredits: require("./enter-4-digits-bank-account-tax-credits.js"),
+  EnterRecentTaxCreditsPayment: require("./enter-recent-tax-credits-payment.js"),
   WhatTypeSelfAssessment: require("./what-type-self-assessment.js"),
   ErrorPage: require("./error.js"),
   RelyingPartyPage: require("./relying-party.js"),

--- a/tests/browser/step_definitions/enter-recent-tax-credits-payment.js
+++ b/tests/browser/step_definitions/enter-recent-tax-credits-payment.js
@@ -1,0 +1,25 @@
+const { Then, When } = require("@cucumber/cucumber");
+const { EnterRecentTaxCreditsPayment } = require("../pages");
+const { expect } = require("chai");
+
+Then(
+  "they should see the enter-recent-tax-credits-payment question page",
+  async function () {
+    const singleAmountQuestionPage = new EnterRecentTaxCreditsPayment(
+      this.page
+    );
+
+    expect(singleAmountQuestionPage.isCurrentPage()).to.be.true;
+  }
+);
+
+When(
+  "they enter correct account number and continue from the enter-recent-tax-credits-payment question page",
+  async function () {
+    const singleAmountQuestionPage = new EnterRecentTaxCreditsPayment(
+      this.page
+    );
+    await singleAmountQuestionPage.answer("1234");
+    await singleAmountQuestionPage.continue();
+  }
+);

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -67,6 +67,12 @@
     "taxCredits": [
       {
         "questionKey": "ita-bankaccount"
+      },
+      {
+        "questionKey": "tc-amount",
+        "info": {
+          "months": "3"
+        }
       }
     ],
     "selfAssessment": [

--- a/tests/unit/src/presenters/question-to-content.test.js
+++ b/tests/unit/src/presenters/question-to-content.test.js
@@ -1,8 +1,10 @@
 const presenters = require("../../../../src/presenters");
+const taxCreditsMonths = require("../../../../src/utils/tax-credits-months");
 
 describe("question-to-content", () => {
   let translate;
   let question;
+  let language;
 
   beforeEach(() => {
     question = {
@@ -10,13 +12,15 @@ describe("question-to-content", () => {
     };
 
     translate = jest.fn();
+    language = "en";
   });
 
   it("should call translate using questionID", () => {
-    presenters.questionToContent(question, translate);
+    presenters.questionToContent(question, translate, language);
 
     expect(translate).toHaveBeenCalledWith(
-      "fields.rti-payslip-national-insurance.content"
+      "fields.rti-payslip-national-insurance.content",
+      {}
     );
   });
 
@@ -24,9 +28,39 @@ describe("question-to-content", () => {
     it("should return translated content when found", () => {
       translate.mockReturnValue("translated question content");
 
-      const result = presenters.questionToContent(question, translate);
+      const result = presenters.questionToContent(
+        question,
+        translate,
+        language
+      );
 
       expect(result).toBe("translated question content");
+    });
+
+    it("should include months information in the translated content when months is defined", () => {
+      question.info = {
+        months: "3",
+      };
+
+      const { dynamicDate } = taxCreditsMonths(
+        question?.info?.months,
+        language
+      );
+      presenters.questionToContent(question, translate, language);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.content",
+        { dynamicDate }
+      );
+    });
+
+    it("should not include months information in the translated content when months is not defined", () => {
+      presenters.questionToContent(question, translate, language);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.content",
+        {}
+      );
     });
   });
 });

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -1,5 +1,6 @@
 const presenters = require("../../../../src/presenters");
 const taxYearToRange = require("../../../../src/utils/tax-year-to-range");
+const taxCreditsMonths = require("../../../../src/utils/tax-credits-months");
 
 Date.now = jest.fn(() => new Date("2024-05-01"));
 
@@ -118,6 +119,42 @@ describe("question-to-inset", () => {
     });
 
     it("should not include tax year information in the translated inset when currentTaxYear is not defined", () => {
+      question = {
+        questionKey: "rti-payslip-national-insurance",
+        info: {},
+      };
+
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        {}
+      );
+    });
+  });
+
+  describe("question-to-inset with months", () => {
+    it("should include months information in the translated inset when months is defined", () => {
+      question = {
+        questionKey: "rti-payslip-national-insurance",
+        info: {
+          months: "3",
+        },
+      };
+
+      const { dynamicDate } = taxCreditsMonths(
+        question?.info?.months,
+        englishLanguage
+      );
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        "fields.rti-payslip-national-insurance.inset",
+        { dynamicDate }
+      );
+    });
+
+    it("should not include months information in the translated inset when months is not defined", () => {
       question = {
         questionKey: "rti-payslip-national-insurance",
         info: {},

--- a/tests/unit/src/utils/text-credits-months.test.js
+++ b/tests/unit/src/utils/text-credits-months.test.js
@@ -1,0 +1,28 @@
+const moment = require("moment");
+const taxCreditsMonths = require("../../../../src/utils/tax-credits-months");
+
+describe("tax-credits-months", () => {
+  const language = "en";
+
+  beforeEach(() => {
+    moment.locale(language);
+  });
+
+  it("should return empty object when months is undefined", () => {
+    const result = taxCreditsMonths(undefined, language);
+
+    expect(result).toEqual({});
+  });
+
+  it("should return object with dynamicDate when months is defined", () => {
+    const months = "3";
+    const dynamicDate = moment()
+      .subtract(months, "months")
+      .locale(language)
+      .format("D MMMM YYYY");
+
+    const result = taxCreditsMonths(months, language);
+
+    expect(result).toEqual({ dynamicDate });
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

URL path: /enter-recent-tax-credits-payment
Question key: tc-amount

Add context along with welsh translations
Add to the question key map and grouped with taxCredits 
Add steps to create the happy path browser test for taxCredits questions 
Pulled out logic from question-to-inset into a utils function which is still called inside inset but can also be used elsewhere Added new taxCreditsMonths function to question-to-content for when dynamicDate is used with the content translations

<img width="600" alt="Screenshot 2024-04-25 at 13 36 52" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/cdacf200-bd57-4035-bab7-dd3d79de0025">


### Why did it change

As a user I want to enter information from my tax credits payments so that I can prove my identity

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4655](https://govukverify.atlassian.net/browse/PYIC-4655)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-4655]: https://govukverify.atlassian.net/browse/PYIC-4655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ