### PR TITLE
PYIC-5705: Generic imposter config

### DIFF
--- a/tests/browser/features/happy.feature
+++ b/tests/browser/features/happy.feature
@@ -2,7 +2,7 @@ Feature: Happy path
 
   Successful journey through the system and back to the RP
 
-  @mock-api:payslips @payslips-journey
+  @mock-api:questions-payslips @payslips-journey
   Scenario: Happy Path for payslips-journey
     Given Happy Harriet is using the system
     And they have started the journey
@@ -14,7 +14,7 @@ Feature: Happy path
     When they enter amount and continue from the Enter Tax Payslip question page
     Then they should be redirected as a success
 
-  @mock-api:p60 @p60-journey
+  @mock-api:questions-p60 @p60-journey
   Scenario: Happy Path for p60-journey
     Given Happy Harriet is using the system
     And they have started the journey
@@ -38,7 +38,7 @@ Feature: Happy path
     When they enter amount and continue from the "enter-employees-contributions-p60" question page
     Then they should be redirected as a success
 
-  @mock-api:selfAssessment @selfAssessment-journey
+  @mock-api:questions-selfAssessment @selfAssessment-journey
   Scenario: Happy Path for selfAssessment-journey
     Given Happy Harriet is using the system
     And they have started the journey
@@ -50,7 +50,7 @@ Feature: Happy path
     When they enter correct pension details
     Then they should be redirected as a success
 
-  @mock-api:selfAssessmentShort @selfAssessment-journey
+  @mock-api:questions-selfAssessmentShort @selfAssessment-journey
   Scenario: Happy Path for selfAssessment-journey
     Given Happy Harriet is using the system
     And they have started the journey
@@ -62,7 +62,7 @@ Feature: Happy path
     When they enter correct pension details
     Then they should be redirected as a success
 
-  @mock-api:taxCredits @taxCredits-journey
+  @mock-api:questions-taxCredits @taxCredits-journey
   Scenario: Happy Path for taxCredits-journey
     Given Happy Harriet is using the system
     And they have started the journey

--- a/tests/browser/features/prove-identity-another-way.feature
+++ b/tests/browser/features/prove-identity-another-way.feature
@@ -1,4 +1,4 @@
-@mock-api:abandon @prove-identity-another-way
+@mock-api:questions-abandon @prove-identity-another-way
 Feature: Prove identity another way
 
   Background:

--- a/tests/docker/compose.yml
+++ b/tests/docker/compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   mocks:
-    image: outofcoffee/imposter:3.25.1
+    image: outofcoffee/imposter:3.38.3
     volumes:
       - "../imposter:/opt/imposter/config"
     ports:

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -12,268 +12,6 @@ system:
       preloadFile: data/questions.json
 
 resources:
-  ### "payslips" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "payslips"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "payslips"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "payslips"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "payslips",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "payslips"
-    response:
-      scriptFile: scripts/post-answer.groovy
-
-  ### "p60" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "p60"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "p60"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "p60"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "p60",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "p60"
-    response:
-      scriptFile: scripts/post-answer.groovy
-
-  ### "taxCredits" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "taxCredits"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "taxCredits"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "taxCredits"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "taxCredits",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "taxCredits"
-    response:
-      scriptFile: scripts/post-answer.groovy
-
-  ### "selfAssessment" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "selfAssessment"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "selfAssessment"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "selfAssessment"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "selfAssessment",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "selfAssessment"
-    response:
-      scriptFile: scripts/post-answer.groovy
-
-  ### "income from pensions tax return" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "selfAssessmentShort"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "selfAssessmentShort"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "selfAssessmentShort"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "selfAssessmentShort",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "selfAssessmentShort"
-    response:
-      scriptFile: scripts/post-answer.groovy
-
-  ### 'insufficient-questions' journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: insufficient-questions
-    response:
-      statusCode: 204
-
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "insufficient-questions"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "insufficient-questions",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "insufficient-questions"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
 
   ### 'question-500' journey ###
   - method: GET
@@ -357,24 +95,21 @@ resources:
       content: |
         {}
   ### 'abandon' journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "abandon"
-    response:
-      scriptFile: scripts/get-question.groovy
-
+  # As this handler is first in this file it takes precedence over the default handler for /authorization for questions
+  # (see below)
   - method: GET
     path: /authorization
     requestHeaders:
-      session-id: "abandon"
+      session-id:
+        value: "questions-abandon.+"
+        operator: Matches
     response:
       statusCode: 500
       content: |
         {
           "redirect_uri": "http://example.net",
           "oauth_error": {
-            "error_description": "acces-denied",
+            "error_description": "access-denied",
             "error": "access_denied"
           }
         }
@@ -413,3 +148,64 @@ resources:
       statusCode: 400
       content: |
         {}
+
+  # Default journey that will get questions from the question store matching the initial client_id value as long as that
+  # value starts with "questions-"
+  - method: POST
+    path: /session
+    # Capture the client_id value here so we can use it in the response
+    capture:
+      journey:
+        jsonPath: $.client_id
+        store: request
+    requestBody:
+      jsonPath: $.client_id
+      value: "questions-.+" # match anything starting with "questions-"
+      operator: Matches
+    response:
+      statusCode: 201
+      template: true
+      # Set the session id to a unique value based on the client_id. The random element means that we can run tests
+      # multiple times without clashes in the stores.
+      content: |
+        {
+          "session_id": "${stores.request.journey}-SEPARATOR-${random.uuid()}",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id:
+        value: "questions-.+-SEPARATOR-.+" # Match our session_id pattern
+        operator: Matches
+    response:
+      scriptFile: scripts/get-question.groovy
+
+  - method: POST
+    path: /answer
+    requestHeaders:
+      session-id:
+        value: "questions-.+-SEPARATOR-.+" # Match our session_id pattern
+        operator: Matches
+    response:
+      scriptFile: scripts/post-answer.groovy
+
+  - method: GET
+    path: /authorization
+    requestHeaders:
+      session-id:
+        value: "questions-.+-SEPARATOR-.+" # Match our session_id pattern
+        operator: Matches
+    response:
+      template: true
+      statusCode: 200
+      content: |
+        {
+          "authorizationCode": {
+            "value":"auth-code-${random.uuid()}"
+          },
+          "state":"sT@t3",
+          "redirect_uri":"http://example.net"
+        }

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -12,7 +12,6 @@ system:
       preloadFile: data/questions.json
 
 resources:
-
   ### 'question-500' journey ###
   - method: GET
     path: /question

--- a/tests/imposter/scripts/get-question.groovy
+++ b/tests/imposter/scripts/get-question.groovy
@@ -1,13 +1,17 @@
-def serializer = new groovy.json.JsonOutput();
+// The session-id should be in the form "questions-<journeyType>-SEPARATOR-<random-guid>"
+def sessionId = context.request.headers['session-id']
+def prefix = "questions-";
+def separatorIndex = sessionId.indexOf("-SEPARATOR-");
+def journeyType = sessionId.substring(prefix.length(), separatorIndex)
 
-def journeyType = context.request.headers['session-id']
+def serializer = new groovy.json.JsonOutput();
 
 def questionStore = stores.open("questions");
 def questions = questionStore.load("questions")[journeyType];
 
-def currentQuestionStore = stores.open("currentQuestion" + journeyType)
+def currentQuestionStore = stores.open("currentQuestion" + sessionId)
 
-def answers = stores.open("answers" + journeyType).loadAll();
+def answers = stores.open("answers" + sessionId).loadAll();
 
 if (answers.size() >= questions.size()) {
     respond {

--- a/tests/imposter/scripts/post-answer.groovy
+++ b/tests/imposter/scripts/post-answer.groovy
@@ -1,15 +1,19 @@
+// The session-id should be in the form "questions-<journeyType>-SEPARATOR-<random-guid>"
+def sessionId = context.request.headers['session-id']
+def prefix = "questions-";
+def separatorIndex = sessionId.indexOf("-SEPARATOR-");
+def journeyType = sessionId.substring(prefix.length(), separatorIndex)
+
 def parser = new groovy.json.JsonSlurper();
 def body = parser.parseText(context.request.body);
-def journeyType = context.request.headers['session-id']
-
 def questionKey = body.key;
 def answer = body.value;
 
 def questionStore = stores.open("questions");
 def questions = questionStore.load("questions")[journeyType];
-def currentQuestionKey = stores.open("currentQuestion" + journeyType).load("currentQuestionKey");
+def currentQuestionKey = stores.open("currentQuestion" + sessionId).load("currentQuestionKey");
 
-def answerStore = stores.open("answers" + journeyType);
+def answerStore = stores.open("answers" + sessionId);
 def answers = answerStore.loadAll();
 
 def result = questions.find {question -> question.questionKey == questionKey};


### PR DESCRIPTION
NOTE Only one (or neither) of this and https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/pull/175 should be merged. These both solve the same problem in different ways.

Update imposter configuration so that question journeys are more generic and tests can be run multiple times without restarting the imposter server

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This sets up imposter configuration so that all question journeys are handled by the same handlers using regexes.
Each test gets a unique session ID so it gets a unique question and answer store and doesn't clash with itself or other tests when run multiple times.

### Why did it change

The imposter tests only work once before you have to restart the imposter server to reset the question and answer stores.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5705](https://govukverify.atlassian.net/browse/PYIC-5705)


[PYIC-5705]: https://govukverify.atlassian.net/browse/PYIC-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ