### PR TITLE
PYIC-5705 imposter reset stores

### DIFF
--- a/tests/docker/compose.yml
+++ b/tests/docker/compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   mocks:
-    image: outofcoffee/imposter:3.25.1
+    image: outofcoffee/imposter:3.38.3
     volumes:
       - "../imposter:/opt/imposter/config"
     ports:

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -15,6 +15,9 @@ resources:
   ### "payslips" journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "payslips"
@@ -61,6 +64,9 @@ resources:
   ### "p60" journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "p60"
@@ -107,6 +113,9 @@ resources:
   ### "taxCredits" journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "taxCredits"
@@ -153,6 +162,9 @@ resources:
   ### "selfAssessment" journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "selfAssessment"
@@ -199,6 +211,9 @@ resources:
   ### "income from pensions tax return" journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "selfAssessmentShort"
@@ -245,6 +260,9 @@ resources:
   ### 'insufficient-questions' journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "insufficient-questions"
@@ -304,6 +322,9 @@ resources:
   ### 'authorization-error' journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "authorization-error"
@@ -342,6 +363,9 @@ resources:
   ### 'session-400' journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "session-400"
@@ -354,6 +378,9 @@ resources:
   ### 'session-500' journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "session-500"
@@ -366,6 +393,9 @@ resources:
   ### 'abandon' journey ###
   - method: POST
     path: /session
+    steps:
+      - type: script
+        file: scripts/reset-stores.groovy
     requestBody:
       jsonPath: $.client_id
       value: "abandon"

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -13,29 +13,6 @@ system:
 
 resources:
   ### "payslips" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "payslips"
-    response:
-      scriptFile: scripts/get-question.groovy
-
-  - method: GET
-    path: /authorization
-    requestHeaders:
-      session-id: "payslips"
-    response:
-      template: true
-      statusCode: 200
-      content: |
-        {
-          "authorizationCode": {
-            "value":"auth-code-${random.uuid()}"
-          },
-          "state":"sT@t3",
-          "redirect_uri":"http://example.net"
-        }
-
   - method: POST
     path: /session
     requestBody:
@@ -51,6 +28,13 @@ resources:
           "redirect_uri": "http://example.net"
         }
 
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "payslips"
+    response:
+      scriptFile: scripts/get-question.groovy
+
   - method: POST
     path: /answer
     requestHeaders:
@@ -58,18 +42,10 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
-  ### "p60" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "p60"
-    response:
-      scriptFile: scripts/get-question.groovy
-
   - method: GET
     path: /authorization
     requestHeaders:
-      session-id: "p60"
+      session-id: "payslips"
     response:
       template: true
       statusCode: 200
@@ -82,6 +58,7 @@ resources:
           "redirect_uri":"http://example.net"
         }
 
+  ### "p60" journey ###
   - method: POST
     path: /session
     requestBody:
@@ -97,6 +74,13 @@ resources:
           "redirect_uri": "http://example.net"
         }
 
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "p60"
+    response:
+      scriptFile: scripts/get-question.groovy
+
   - method: POST
     path: /answer
     requestHeaders:
@@ -104,18 +88,10 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
-  ### "taxCredits" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "taxCredits"
-    response:
-      scriptFile: scripts/get-question.groovy
-
   - method: GET
     path: /authorization
     requestHeaders:
-      session-id: "taxCredits"
+      session-id: "p60"
     response:
       template: true
       statusCode: 200
@@ -127,6 +103,8 @@ resources:
           "state":"sT@t3",
           "redirect_uri":"http://example.net"
         }
+
+  ### "taxCredits" journey ###
   - method: POST
     path: /session
     requestBody:
@@ -141,6 +119,14 @@ resources:
           "state": "sT@t3",
           "redirect_uri": "http://example.net"
         }
+
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "taxCredits"
+    response:
+      scriptFile: scripts/get-question.groovy
+
   - method: POST
     path: /answer
     requestHeaders:
@@ -148,18 +134,10 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
-  ### "selfAssessment" journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: "selfAssessment"
-    response:
-      scriptFile: scripts/get-question.groovy
-
   - method: GET
     path: /authorization
     requestHeaders:
-      session-id: "selfAssessment"
+      session-id: "taxCredits"
     response:
       template: true
       statusCode: 200
@@ -171,6 +149,8 @@ resources:
           "state":"sT@t3",
           "redirect_uri":"http://example.net"
         }
+
+  ### "selfAssessment" journey ###
   - method: POST
     path: /session
     requestBody:
@@ -185,6 +165,14 @@ resources:
           "state": "sT@t3",
           "redirect_uri": "http://example.net"
         }
+
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: "selfAssessment"
+    response:
+      scriptFile: scripts/get-question.groovy
+
   - method: POST
     path: /answer
     requestHeaders:
@@ -192,13 +180,51 @@ resources:
     response:
       scriptFile: scripts/post-answer.groovy
 
+  - method: GET
+    path: /authorization
+    requestHeaders:
+      session-id: "selfAssessment"
+    response:
+      template: true
+      statusCode: 200
+      content: |
+        {
+          "authorizationCode": {
+            "value":"auth-code-${random.uuid()}"
+          },
+          "state":"sT@t3",
+          "redirect_uri":"http://example.net"
+        }
+
   ### "income from pensions tax return" journey ###
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+      value: "selfAssessmentShort"
+    response:
+      statusCode: 201
+      template: true
+      content: |
+        {
+          "session_id": "selfAssessmentShort",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+
   - method: GET
     path: /question
     requestHeaders:
       session-id: "selfAssessmentShort"
     response:
       scriptFile: scripts/get-question.groovy
+
+  - method: POST
+    path: /answer
+    requestHeaders:
+      session-id: "selfAssessmentShort"
+    response:
+      scriptFile: scripts/post-answer.groovy
 
   - method: GET
     path: /authorization
@@ -215,35 +241,8 @@ resources:
           "state":"sT@t3",
           "redirect_uri":"http://example.net"
         }
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "selfAssessmentShort"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "selfAssessmentShort",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "selfAssessmentShort"
-    response:
-      scriptFile: scripts/post-answer.groovy
 
   ### 'insufficient-questions' journey ###
-  - method: GET
-    path: /question
-    requestHeaders:
-      session-id: insufficient-questions
-    response:
-      statusCode: 204
-
   - method: POST
     path: /session
     requestBody:
@@ -258,6 +257,13 @@ resources:
           "state": "sT@t3",
           "redirect_uri": "http://example.net"
         }
+
+  - method: GET
+    path: /question
+    requestHeaders:
+      session-id: insufficient-questions
+    response:
+      statusCode: 204
 
   - method: GET
     path: /authorization
@@ -356,13 +362,36 @@ resources:
       template: true
       content: |
         {}
+
   ### 'abandon' journey ###
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+      value: "abandon"
+    response:
+      statusCode: 201
+      template: true
+      content: |
+        {
+          "session_id": "abandon",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+
   - method: GET
     path: /question
     requestHeaders:
       session-id: "abandon"
     response:
       scriptFile: scripts/get-question.groovy
+
+  - method: POST
+    path: /answer
+    requestHeaders:
+      session-id: "abandon"
+    response:
+      scriptFile: scripts/post-answer.groovy
 
   - method: GET
     path: /authorization
@@ -378,26 +407,6 @@ resources:
             "error": "access_denied"
           }
         }
-  - method: POST
-    path: /session
-    requestBody:
-      jsonPath: $.client_id
-      value: "abandon"
-    response:
-      statusCode: 201
-      template: true
-      content: |
-        {
-          "session_id": "abandon",
-          "state": "sT@t3",
-          "redirect_uri": "http://example.net"
-        }
-  - method: POST
-    path: /answer
-    requestHeaders:
-      session-id: "abandon"
-    response:
-      scriptFile: scripts/post-answer.groovy
 
   - method: POST
     path: /abandon
@@ -405,6 +414,7 @@ resources:
       statusCode: 200
       content: |
         {}
+
   - method: POST
     path: /abandon
     requestHeaders:

--- a/tests/imposter/scripts/reset-stores.groovy
+++ b/tests/imposter/scripts/reset-stores.groovy
@@ -1,0 +1,18 @@
+static void clearStore(io.gatehill.imposter.store.inmem.InMemoryStore store) {
+    def allItems = store.loadAll();
+    def allKeys = allItems.keySet();
+
+    for (key in allKeys) {
+        store.delete(key);
+    }
+}
+
+def jsonSlurper = new groovy.json.JsonSlurper()
+def parsedBody = jsonSlurper.parseText(context.request.body)
+def journeyType = parsedBody.client_id
+
+def currentQuestionStore = stores.open("currentQuestion" + journeyType);
+def answerStore = stores.open("answers" + journeyType);
+
+clearStore(currentQuestionStore);
+clearStore(answerStore);


### PR DESCRIPTION
NOTE Only one (or neither) of this and https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/pull/174 should be merged. These both solve the same problem in different ways.

Update imposter configuration so that the imposter stores are cleared each time a new test runs.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This sets up imposter configuration so that tests using sets of questions wipe their stores before running.

### Why did it change

The imposter tests only work once before you have to restart the imposter server to reset the question and answer stores.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5705](https://govukverify.atlassian.net/browse/PYIC-5705)


[PYIC-5705]: https://govukverify.atlassian.net/browse/PYIC-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ