### PR TITLE
PYIC:4920: Validation - Amounts with pounds only and Welsh translations

### DIFF
--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -53,21 +53,17 @@ class SingleAmountQuestionController extends BaseController {
         return callback(err);
       }
 
-      let userInput = req.body[req.session.question.questionKey];
+      const questionKey = req.session.question.questionKey;
+
+      let userInput = req.body[questionKey];
       userInput = userInput && fields.stripSpaces(userInput);
 
-      const keysToStripDecimal = [
-        "rti-p60-earnings-above-pt",
-        "rti-p60-postgraduate-loan-deductions",
-        "rti-p60-student-loan-deductions",
-      ];
-
-      if (keysToStripDecimal.includes(req.session.question.questionKey)) {
+      if (req.form.options.fields[questionKey]?.stripDecimal) {
         userInput = fields.stripDecimal(userInput);
       }
 
       try {
-        await submitAnswer(req, req.session.question.questionKey, userInput);
+        await submitAnswer(req, questionKey, userInput);
 
         req.session.question = undefined;
 

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -56,7 +56,13 @@ class SingleAmountQuestionController extends BaseController {
       let userInput = req.body[req.session.question.questionKey];
       userInput = userInput && fields.stripSpaces(userInput);
 
-      if (req.session.question.questionKey === "rti-p60-earnings-above-pt") {
+      const keysToStripDecimal = [
+        "rti-p60-earnings-above-pt",
+        "rti-p60-postgraduate-loan-deductions",
+        "rti-p60-student-loan-deductions",
+      ];
+
+      if (keysToStripDecimal.includes(req.session.question.questionKey)) {
         userInput = fields.stripDecimal(userInput);
       }
 

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -2,8 +2,8 @@ const debug = require("debug")("load-question");
 const path = require("path");
 const BaseController = require("hmpo-form-wizard").Controller;
 const presenters = require("../../../presenters");
-const fields = require("../fieldsHelper");
 const { submitAnswer, getNextQuestion } = require("../service");
+const fields = require("../fieldsHelper");
 
 class SingleAmountQuestionController extends BaseController {
   configure(req, res, next) {

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -2,6 +2,7 @@ const debug = require("debug")("load-question");
 const path = require("path");
 const BaseController = require("hmpo-form-wizard").Controller;
 const presenters = require("../../../presenters");
+const fields = require("../fieldsHelper");
 const { submitAnswer, getNextQuestion } = require("../service");
 
 class SingleAmountQuestionController extends BaseController {
@@ -52,7 +53,12 @@ class SingleAmountQuestionController extends BaseController {
         return callback(err);
       }
 
-      const userInput = req.body[req.session.question.questionKey];
+      let userInput = req.body[req.session.question.questionKey];
+      userInput = userInput && fields.stripSpaces(userInput);
+
+      if (req.session.question.questionKey === "rti-p60-earnings-above-pt") {
+        userInput = fields.stripDecimal(userInput);
+      }
 
       try {
         await submitAnswer(req, req.session.question.questionKey, userInput);

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -1,4 +1,4 @@
-const { numericWithOptionalDecimal } = require("./fieldsHelper");
+const { numericWithOptionalDecimalZeros } = require("./fieldsHelper");
 
 module.exports = {
   "ita-bankaccount": {
@@ -12,7 +12,7 @@ module.exports = {
       "required",
       {
         type: "regex",
-        arguments: [numericWithOptionalDecimal],
+        arguments: [numericWithOptionalDecimalZeros],
       },
     ],
   },
@@ -22,7 +22,7 @@ module.exports = {
       "required",
       {
         type: "regex",
-        arguments: [numericWithOptionalDecimal],
+        arguments: [numericWithOptionalDecimalZeros],
       },
     ],
   },
@@ -32,7 +32,7 @@ module.exports = {
       "required",
       {
         type: "regex",
-        arguments: [numericWithOptionalDecimal],
+        arguments: [numericWithOptionalDecimalZeros],
       },
     ],
   },

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -4,6 +4,16 @@ module.exports = {
     journeyKey: "itabankaccount",
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
   },
+  "rti-p60-earnings-above-pt": {
+    type: "text",
+    validate: [
+      "required",
+      {
+        type: "regex",
+        arguments: [/^\s*\d+(\s*\.\s*0+)?\s*$/], // Matches numbers with optional decimal zeros, allowing whitespace. Example: " 123 ", "123.00", "123.0", "123 . 00", etc.
+      },
+    ],
+  },
   abandonRadio: {
     type: "radios",
     items: ["stop", "continue"],

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -1,3 +1,5 @@
+const { numericWithOptionalDecimal } = require("./fieldshelper");
+
 module.exports = {
   "ita-bankaccount": {
     type: "text",
@@ -10,7 +12,27 @@ module.exports = {
       "required",
       {
         type: "regex",
-        arguments: [/^\s*\d+(\s*\.\s*0+)?\s*$/], // Matches numbers with optional decimal zeros, allowing whitespace. Example: " 123 ", "123.00", "123.0", "123 . 00", etc.
+        arguments: [numericWithOptionalDecimal],
+      },
+    ],
+  },
+  "rti-p60-postgraduate-loan-deductions": {
+    type: "text",
+    validate: [
+      "required",
+      {
+        type: "regex",
+        arguments: [numericWithOptionalDecimal],
+      },
+    ],
+  },
+  "rti-p60-student-loan-deductions": {
+    type: "text",
+    validate: [
+      "required",
+      {
+        type: "regex",
+        arguments: [numericWithOptionalDecimal],
       },
     ],
   },

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -1,4 +1,4 @@
-const { numericWithOptionalDecimal } = require("./fieldshelper");
+const { numericWithOptionalDecimal } = require("./fieldsHelper");
 
 module.exports = {
   "ita-bankaccount": {

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -15,6 +15,7 @@ module.exports = {
         arguments: [numericWithOptionalDecimalZeros],
       },
     ],
+    stripDecimal: true,
   },
   "rti-p60-postgraduate-loan-deductions": {
     type: "text",
@@ -25,6 +26,7 @@ module.exports = {
         arguments: [numericWithOptionalDecimalZeros],
       },
     ],
+    stripDecimal: true,
   },
   "rti-p60-student-loan-deductions": {
     type: "text",
@@ -35,6 +37,7 @@ module.exports = {
         arguments: [numericWithOptionalDecimalZeros],
       },
     ],
+    stripDecimal: true,
   },
   abandonRadio: {
     type: "radios",

--- a/src/app/kbv/fieldsHelper.js
+++ b/src/app/kbv/fieldsHelper.js
@@ -1,0 +1,12 @@
+function stripSpaces(value) {
+  return value.replace(/\s/g, "");
+}
+
+function stripDecimal(value) {
+  return value.replace(/\.\d*/, "");
+}
+
+module.exports = {
+  stripSpaces,
+  stripDecimal,
+};

--- a/src/app/kbv/fieldsHelper.js
+++ b/src/app/kbv/fieldsHelper.js
@@ -6,10 +6,10 @@ function stripDecimal(value) {
   return value.replace(/\.\d*/, "");
 }
 
-const numericWithOptionalDecimal = /^\s*\d+(\s*\.\s*0+)?\s*$/; // Matches numbers with optional decimal zeros, allowing whitespace. Example: " 123 ", "123.00", "123.0", "123 . 00", etc.
+const numericWithOptionalDecimalZeros = /^\s*\d+(\s*\.\s*0+)?\s*$/; // Matches numbers with optional decimal zeros, allowing whitespace. Example: " 123 ", "123.00", "123.0", "123 . 00", etc.
 
 module.exports = {
   stripSpaces,
   stripDecimal,
-  numericWithOptionalDecimal,
+  numericWithOptionalDecimalZeros,
 };

--- a/src/app/kbv/fieldsHelper.js
+++ b/src/app/kbv/fieldsHelper.js
@@ -6,7 +6,10 @@ function stripDecimal(value) {
   return value.replace(/\.\d*/, "");
 }
 
+const numericWithOptionalDecimal = /^\s*\d+(\s*\.\s*0+)?\s*$/; // Matches numbers with optional decimal zeros, allowing whitespace. Example: " 123 ", "123.00", "123.0", "123 . 00", etc.
+
 module.exports = {
   stripSpaces,
   stripDecimal,
+  numericWithOptionalDecimal,
 };

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -50,6 +50,7 @@ module.exports = {
   "/question/enter-postgraduate-loan-deductions-p60": {
     backLink: null,
     controller: singleAmountQuestionController,
+    fields: ["rti-p60-postgraduate-loan-deductions"],
     next: "load-question",
   },
   "/question/enter-statutory-shared-parental-pay-p60": {
@@ -70,6 +71,7 @@ module.exports = {
   "/question/enter-student-loan-deductions-p60": {
     backLink: null,
     controller: singleAmountQuestionController,
+    fields: ["rti-p60-student-loan-deductions"],
     next: "load-question",
   },
   "/question/enter-employees-contributions-p60": {

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -44,6 +44,7 @@ module.exports = {
   "/question/enter-earnings-above-pt-p60": {
     backLink: null,
     controller: singleAmountQuestionController,
+    fields: ["rti-p60-earnings-above-pt"],
     next: "load-question",
   },
   "/question/enter-postgraduate-loan-deductions-p60": {

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -10,6 +10,9 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   label: Swm
   hint: Er enghraifft, 24368
+  validation:
+    required: Rhowch swm
+    regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-postgraduate-loan-deductions:
   label: Swm
   hint: For example, 765

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -16,6 +16,9 @@ rti-p60-earnings-above-pt:
 rti-p60-postgraduate-loan-deductions:
   label: Swm
   hint: For example, 765
+  validation:
+    required: Rhowch swm
+    regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-statutory-shared-parental-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
@@ -28,6 +31,9 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   label: Swm
   hint: Er enghraifft, 765
+  validation:
+    required: Rhowch swm
+    regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-employee-ni-contributions:
   label: Swm
   hint: Er enghraifft, 836.16

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -10,6 +10,9 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   label: Amount
   hint: For example, 24368
+  validation:
+    required: Enter an amount
+    regex: Amount must be a whole number, like 123
 rti-p60-postgraduate-loan-deductions:
   label: Amount
   hint: For example, 765

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -16,6 +16,9 @@ rti-p60-earnings-above-pt:
 rti-p60-postgraduate-loan-deductions:
   label: Amount
   hint: For example, 765
+  validation:
+    required: Enter an amount
+    regex: Amount must be a whole number, like 123
 rti-p60-statutory-shared-parental-pay:
   label: Amount
   hint: For example, 15620.75
@@ -28,6 +31,9 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   label: Amount
   hint: For example, 765
+  validation:
+    required: Enter an amount
+    regex: Amount must be a whole number, like 123
 rti-p60-employee-ni-contributions:
   label: Amount
   hint: For example, 836.16

--- a/tests/browser/features/validation.feature
+++ b/tests/browser/features/validation.feature
@@ -1,0 +1,29 @@
+Feature: Validation scenarios
+
+  @mock-api:questions-p60 @p60-journey
+  Scenario: Happy Path for p60-journey
+    Given Happy Harriet is using the system
+    And they have started the journey
+    Then they should see the answer security questions page
+    When they continue from answer security questions
+    Then they should see the "enter-total-for-year-p60" question page
+    When they enter amount and continue from the "enter-total-for-year-p60" question page
+    Then they should see the "enter-earnings-above-pt-p60" question page
+    When they do not enter an amount and continue from the enter-earnings-above-pt-p60 question page
+    Then they should see enter amount error message
+    When they enter an invalid amount and continue from the enter-earnings-above-pt-p60 question page
+    Then they should see enter amount error message
+    When they enter amount and continue from the "enter-earnings-above-pt-p60" question page
+    Then they should see the "enter-postgraduate-loan-deductions-p60" question page
+    When they enter amount and continue from the "enter-postgraduate-loan-deductions-p60" question page
+    Then they should see the "enter-statutory-shared-parental-pay-p60" question page
+    When they enter amount and continue from the "enter-statutory-shared-parental-pay-p60" question page
+    Then they should see the "enter-statutory-adoption-pay-p60" question page
+    When they enter amount and continue from the "enter-statutory-adoption-pay-p60" question page
+    Then they should see the "enter-statutory-maternity-pay-p60" question page
+    When they enter amount and continue from the "enter-statutory-maternity-pay-p60" question page
+    Then they should see the "enter-student-loan-deductions-p60" question page
+    When they enter amount and continue from the "enter-student-loan-deductions-p60" question page
+    Then they should see the "enter-employees-contributions-p60" question page
+    When they enter amount and continue from the "enter-employees-contributions-p60" question page
+    Then they should be redirected as a success

--- a/tests/browser/features/validation.feature
+++ b/tests/browser/features/validation.feature
@@ -1,7 +1,7 @@
 Feature: Validation scenarios
 
   @mock-api:questions-p60 @p60-journey
-  Scenario: Happy Path for p60-journey
+  Scenario: Validation Path for p60-journey
     Given Happy Harriet is using the system
     And they have started the journey
     Then they should see the answer security questions page
@@ -9,12 +9,16 @@ Feature: Validation scenarios
     Then they should see the "enter-total-for-year-p60" question page
     When they enter amount and continue from the "enter-total-for-year-p60" question page
     Then they should see the "enter-earnings-above-pt-p60" question page
-    When they do not enter an amount and continue from the enter-earnings-above-pt-p60 question page
+    When they do not enter an amount and continue from the "enter-earnings-above-pt-p60" question page
     Then they should see enter amount error message
-    When they enter an invalid amount and continue from the enter-earnings-above-pt-p60 question page
+    When they enter an invalid amount and continue from the "enter-earnings-above-pt-p60" question page
     Then they should see enter amount error message
     When they enter amount and continue from the "enter-earnings-above-pt-p60" question page
     Then they should see the "enter-postgraduate-loan-deductions-p60" question page
+    When they do not enter an amount and continue from the "enter-postgraduate-loan-deductions-p60" question page
+    Then they should see enter amount error message
+    When they enter an invalid amount and continue from the "enter-postgraduate-loan-deductions-p60" question page
+    Then they should see enter amount error message
     When they enter amount and continue from the "enter-postgraduate-loan-deductions-p60" question page
     Then they should see the "enter-statutory-shared-parental-pay-p60" question page
     When they enter amount and continue from the "enter-statutory-shared-parental-pay-p60" question page
@@ -23,6 +27,10 @@ Feature: Validation scenarios
     Then they should see the "enter-statutory-maternity-pay-p60" question page
     When they enter amount and continue from the "enter-statutory-maternity-pay-p60" question page
     Then they should see the "enter-student-loan-deductions-p60" question page
+    When they do not enter an amount and continue from the "enter-student-loan-deductions-p60" question page
+    Then they should see enter amount error message
+    When they enter an invalid amount and continue from the "enter-student-loan-deductions-p60" question page
+    Then they should see enter amount error message
     When they enter amount and continue from the "enter-student-loan-deductions-p60" question page
     Then they should see the "enter-employees-contributions-p60" question page
     When they enter amount and continue from the "enter-employees-contributions-p60" question page

--- a/tests/browser/pages/answer-p60-questions.js
+++ b/tests/browser/pages/answer-p60-questions.js
@@ -11,12 +11,16 @@ module.exports = class PlaywrightDevPage {
     await this.page.click("#continue");
   }
 
-  async answer() {
-    await this.page.fill('input[type="text"]', "2023");
+  async answer(answer) {
+    await this.page.fill('input[type="text"]', answer);
   }
 
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
     return pathname === this.path;
+  }
+
+  hasErrorSummary() {
+    return this.page.locator(".govuk-error-summary");
   }
 };

--- a/tests/browser/step_definitions/answer-p60-questions.js
+++ b/tests/browser/step_definitions/answer-p60-questions.js
@@ -3,7 +3,7 @@ const { AnswerP60QuestionsPage } = require("../pages");
 const { expect } = require("chai");
 
 Then("they should see the {string} question page", async function (path) {
-  const p60QuestionPage = new AnswerP60QuestionsPage(this.page, path);
+  const p60QuestionPage = new AnswerP60QuestionsPage(this.page, String(path));
 
   expect(p60QuestionPage.isCurrentPage()).to.be.true;
 });
@@ -11,7 +11,7 @@ Then("they should see the {string} question page", async function (path) {
 When(
   "they enter amount and continue from the {string} question page",
   async function (path) {
-    const p60QuestionPage = new AnswerP60QuestionsPage(this.page, path);
+    const p60QuestionPage = new AnswerP60QuestionsPage(this.page, String(path));
     await p60QuestionPage.answer("1234");
     await p60QuestionPage.continue();
   }
@@ -19,8 +19,8 @@ When(
 
 When(
   "they do not enter an amount and continue from the {string} question page",
-  async function () {
-    const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
+  async function (path) {
+    const p60QuestionPage = new AnswerP60QuestionsPage(this.page, String(path));
     await p60QuestionPage.answer("");
     await p60QuestionPage.continue();
   }
@@ -28,8 +28,8 @@ When(
 
 When(
   "they enter an invalid amount and continue from the {string} question page",
-  async function () {
-    const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
+  async function (path) {
+    const p60QuestionPage = new AnswerP60QuestionsPage(this.page, String(path));
     await p60QuestionPage.answer("123.123");
     await p60QuestionPage.continue();
   }
@@ -37,6 +37,5 @@ When(
 
 Then("they should see enter amount error message", async function () {
   const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
-  expect(p60QuestionPage.isCurrentPage()).to.be.true;
   expect(p60QuestionPage.hasErrorSummary).to.not.be.false;
 });

--- a/tests/browser/step_definitions/answer-p60-questions.js
+++ b/tests/browser/step_definitions/answer-p60-questions.js
@@ -12,7 +12,31 @@ When(
   "they enter amount and continue from the {string} question page",
   async function (path) {
     const p60QuestionPage = new AnswerP60QuestionsPage(this.page, path);
-    await p60QuestionPage.answer();
+    await p60QuestionPage.answer("1234");
     await p60QuestionPage.continue();
   }
 );
+
+When(
+  "they do not enter an amount and continue from the enter-earnings-above-pt-p60 question page",
+  async function () {
+    const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
+    await p60QuestionPage.answer("");
+    await p60QuestionPage.continue();
+  }
+);
+
+When(
+  "they enter an invalid amount and continue from the enter-earnings-above-pt-p60 question page",
+  async function () {
+    const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
+    await p60QuestionPage.answer("123.123");
+    await p60QuestionPage.continue();
+  }
+);
+
+Then("they should see enter amount error message", async function () {
+  const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
+  expect(p60QuestionPage.isCurrentPage()).to.be.true;
+  expect(p60QuestionPage.hasErrorSummary).to.not.be.false;
+});

--- a/tests/browser/step_definitions/answer-p60-questions.js
+++ b/tests/browser/step_definitions/answer-p60-questions.js
@@ -18,7 +18,7 @@ When(
 );
 
 When(
-  "they do not enter an amount and continue from the enter-earnings-above-pt-p60 question page",
+  "they do not enter an amount and continue from the {string} question page",
   async function () {
     const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
     await p60QuestionPage.answer("");
@@ -27,7 +27,7 @@ When(
 );
 
 When(
-  "they enter an invalid amount and continue from the enter-earnings-above-pt-p60 question page",
+  "they enter an invalid amount and continue from the {string} question page",
   async function () {
     const p60QuestionPage = new AnswerP60QuestionsPage(this.page);
     await p60QuestionPage.answer("123.123");

--- a/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
@@ -5,6 +5,7 @@ jest.mock("../../../../../../src/app/kbv/service");
 
 const presenters = require("../../../../../../src/presenters");
 jest.mock("../../../../../../src/presenters");
+const fields = require("../../../../../../src/app/kbv/fieldsHelper");
 
 describe("single-amount-question controller", () => {
   let controller;
@@ -176,6 +177,55 @@ describe("single-amount-question controller", () => {
         });
 
         await controller.saveValues(req, res, callback);
+      });
+    });
+
+    describe("#stripSpaces", () => {
+      it("should remove all whitespace characters from the input string", () => {
+        const userInput = "  123 . 00  ";
+        const expectedOutput = "123.00";
+
+        const result = fields.stripSpaces(userInput);
+
+        expect(result).toBe(expectedOutput);
+      });
+    });
+
+    describe("#stripDecimal 'rti-p60-earnings-above-pt'", () => {
+      it("should strip decimal points from input when questionKey is 'rti-p60-earnings-above-pt'", async () => {
+        req.session.question.questionKey = "rti-p60-earnings-above-pt";
+        req.body["rti-p60-earnings-above-pt"] = " 123.00 ";
+
+        const stripDecimal = jest.spyOn(fields, "stripDecimal");
+
+        const superSaveValues = jest
+          .spyOn(BaseController.prototype, "saveValues")
+          .mockImplementation((req, res, callback) => {
+            callback();
+          });
+
+        await controller.saveValues(req, res, next);
+
+        expect(superSaveValues).toHaveBeenCalled();
+        expect(stripDecimal).toHaveBeenCalledWith("123.00");
+      });
+
+      it("should not strip decimal points from input when questionKey is not in the switch statment", async () => {
+        req.session.question.questionKey = "other-question-key";
+        req.body["other-question-key"] = " 123.00 ";
+
+        const stripDecimal = jest.spyOn(fields, "stripDecimal");
+
+        const superSaveValues = jest
+          .spyOn(BaseController.prototype, "saveValues")
+          .mockImplementation((req, res, callback) => {
+            callback();
+          });
+
+        await controller.saveValues(req, res, next);
+
+        expect(superSaveValues).toHaveBeenCalled();
+        expect(stripDecimal).not.toHaveBeenCalled();
       });
     });
   });

--- a/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-amount-question.test.js
@@ -180,19 +180,8 @@ describe("single-amount-question controller", () => {
       });
     });
 
-    describe("#stripSpaces", () => {
-      it("should remove all whitespace characters from the input string", () => {
-        const userInput = "  123 . 00  ";
-        const expectedOutput = "123.00";
-
-        const result = fields.stripSpaces(userInput);
-
-        expect(result).toBe(expectedOutput);
-      });
-    });
-
-    describe("#stripDecimal 'rti-p60-earnings-above-pt'", () => {
-      it("should strip decimal points from input when questionKey is 'rti-p60-earnings-above-pt'", async () => {
+    describe("#stripDecimal", () => {
+      it("should strip decimal points from input when matching questionKey", async () => {
         req.session.question.questionKey = "rti-p60-earnings-above-pt";
         req.body["rti-p60-earnings-above-pt"] = " 123.00 ";
 

--- a/tests/unit/src/app/kbv/fieldsHelper.test.js
+++ b/tests/unit/src/app/kbv/fieldsHelper.test.js
@@ -1,0 +1,59 @@
+const fields = require("../../../../../src/app/kbv/fieldsHelper");
+
+describe("stripSpaces function test", () => {
+  it("should remove all spaces from the input string", () => {
+    const input = "   123   456   ";
+    const expectedOutput = "123456";
+
+    const result = fields.stripSpaces(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should return an empty string if the input is only spaces", () => {
+    const input = "      ";
+    const expectedOutput = "";
+
+    const result = fields.stripSpaces(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should return the input string if it contains no spaces", () => {
+    const input = "123456";
+    const expectedOutput = "123456";
+
+    const result = fields.stripSpaces(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe("stripDecimal function test", () => {
+  it("should remove decimal parts from the input string", () => {
+    const input = "123.00";
+    const expectedOutput = "123";
+
+    const result = fields.stripDecimal(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should remove .0 from the input string", () => {
+    const input = "123.0";
+    const expectedOutput = "123";
+
+    const result = fields.stripDecimal(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should return the input string if it contains no decimal parts", () => {
+    const input = "123";
+    const expectedOutput = "123";
+
+    const result = fields.stripDecimal(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/tests/unit/src/app/kbv/fieldsHelper.test.js
+++ b/tests/unit/src/app/kbv/fieldsHelper.test.js
@@ -58,22 +58,22 @@ describe("stripDecimal function test", () => {
   });
 });
 
-describe("numericWithOptionalDecimal regex test", () => {
+describe("numericWithOptionalDecimalZeros regex test", () => {
   it("should match numbers with optional decimal zeros and whitespace", () => {
-    expect("123").toMatch(fields.numericWithOptionalDecimal);
-    expect("123.00").toMatch(fields.numericWithOptionalDecimal);
-    expect("123.0").toMatch(fields.numericWithOptionalDecimal);
-    expect("123 . 00").toMatch(fields.numericWithOptionalDecimal);
-    expect(" 123 ").toMatch(fields.numericWithOptionalDecimal);
+    expect("123").toMatch(fields.numericWithOptionalDecimalZeros);
+    expect("123.00").toMatch(fields.numericWithOptionalDecimalZeros);
+    expect("123.0").toMatch(fields.numericWithOptionalDecimalZeros);
+    expect("123 . 00").toMatch(fields.numericWithOptionalDecimalZeros);
+    expect(" 123 ").toMatch(fields.numericWithOptionalDecimalZeros);
   });
 
   it("should not match strings without numbers", () => {
-    expect("abc").not.toMatch(fields.numericWithOptionalDecimal);
-    expect("  ").not.toMatch(fields.numericWithOptionalDecimal);
+    expect("abc").not.toMatch(fields.numericWithOptionalDecimalZeros);
+    expect("  ").not.toMatch(fields.numericWithOptionalDecimalZeros);
   });
 
   it("should not match numbers with non-zero decimal parts", () => {
-    expect("123.45").not.toMatch(fields.numericWithOptionalDecimal);
-    expect("123.5").not.toMatch(fields.numericWithOptionalDecimal);
+    expect("123.45").not.toMatch(fields.numericWithOptionalDecimalZeros);
+    expect("123.5").not.toMatch(fields.numericWithOptionalDecimalZeros);
   });
 });

--- a/tests/unit/src/app/kbv/fieldsHelper.test.js
+++ b/tests/unit/src/app/kbv/fieldsHelper.test.js
@@ -57,3 +57,23 @@ describe("stripDecimal function test", () => {
     expect(result).toEqual(expectedOutput);
   });
 });
+
+describe("numericWithOptionalDecimal regex test", () => {
+  it("should match numbers with optional decimal zeros and whitespace", () => {
+    expect("123").toMatch(fields.numericWithOptionalDecimal);
+    expect("123.00").toMatch(fields.numericWithOptionalDecimal);
+    expect("123.0").toMatch(fields.numericWithOptionalDecimal);
+    expect("123 . 00").toMatch(fields.numericWithOptionalDecimal);
+    expect(" 123 ").toMatch(fields.numericWithOptionalDecimal);
+  });
+
+  it("should not match strings without numbers", () => {
+    expect("abc").not.toMatch(fields.numericWithOptionalDecimal);
+    expect("  ").not.toMatch(fields.numericWithOptionalDecimal);
+  });
+
+  it("should not match numbers with non-zero decimal parts", () => {
+    expect("123.45").not.toMatch(fields.numericWithOptionalDecimal);
+    expect("123.5").not.toMatch(fields.numericWithOptionalDecimal);
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Added initial validation to make sure user cant submit anything other than integers, or decimal if only containing .0 .00 etc Once initial validation passes in the saveValues is a switch statement which matches to a questionKey, two new functions are called to strip any whitespace and strip any decimals Added translations
Added new tests for the controller
Added new tests for the two functions


The initial validation regex: 
- Zero or more whitespace characters at the beginning.
- One or more digits.
- An optional group consisting of zero or more whitespace characters, a dot, zero or more whitespace characters, and one or more 0 characters.
- Zero or more whitespace characters at the end.

It will match strings like "123", "123.00", "123.0", "123 . 00", etc.


<img width="600" alt="Screenshot 2024-05-01 at 13 34 12" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/5744ddea-b2e1-43a4-84ca-cc74a1bb9b1f">
<img width="600" alt="Screenshot 2024-05-01 at 13 34 30" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/21be6f9b-3cf7-4658-92c0-7dde52e34a7e">


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4920](https://govukverify.atlassian.net/browse/PYIC-4920)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-4920]: https://govukverify.atlassian.net/browse/PYIC-4920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ