### PR TITLE
LIME-1076: Moving repo permissions and deployment from Orange to Lime

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)
+- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)
 
 ## Checklists
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/identity-sre @govuk-one-login/core-leads @govuk-one-login/core-team
+* @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team @govuk-one-login/cri-lime-team-leads @govuk-one-login/identity-sre @govuk-one-login/core-leads @govuk-one-login/core-team


### PR DESCRIPTION
## Proposed changes

### What changed

Updated permissions, PR templates and Deployments to align to Lime

### Why did it change

To simplify the management of the repo by the Lime team

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1076](https://govukverify.atlassian.net/browse/LIME-1076)


[LIME-1076]: https://govukverify.atlassian.net/browse/LIME-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ