### PR TITLE
PYIC-6421 Workaround for prefix issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express-session": "1.18.0",
         "govuk-frontend": "4.8.0",
         "hmpo-app": "3.0.1",
-        "hmpo-components": "6.4.0",
+        "hmpo-components": "6.5.0",
         "hmpo-form-wizard": "13.0.0",
         "hmpo-i18n": "6.0.1",
         "hmpo-logger": "7.0.1",
@@ -4019,9 +4019,9 @@
       }
     },
     "node_modules/hmpo-components": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.4.0.tgz",
-      "integrity": "sha512-iJqkD3qV8UY6SzJMAocRj3zgZv4MHCpMdHmxjmVOsVZZrwkfADy6RPEhKPm86WH79gEQ3gyYLhhpG1CHX4XNtw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/hmpo-components/-/hmpo-components-6.5.0.tgz",
+      "integrity": "sha512-ZX3773FHNuFhcgkyy4JISBLPP1a6bqlY/nxmQNGndOum5CWEFNu2Om/y9WFHCCPkJN6fQ5ppQKyZ9zUm8Pe42A==",
       "dependencies": {
         "bytes": "^3.1.2",
         "deep-clone-merge": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express-session": "1.18.0",
     "govuk-frontend": "4.8.0",
     "hmpo-app": "3.0.1",
-    "hmpo-components": "6.4.0",
+    "hmpo-components": "6.5.0",
     "hmpo-form-wizard": "13.0.0",
     "hmpo-i18n": "6.0.1",
     "hmpo-logger": "7.0.1",

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -39,7 +39,6 @@ class SingleAmountQuestionController extends BaseController {
           req.lang
         ),
         title: presenters.questionToTitle(req.session.question, req.translate),
-        prefix: "£",
         name: req.session.question?.questionKey,
       };
 

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,6 +1,7 @@
 rti-payslip-national-insurance:
   label: Swm
   hint: Er enghraifft, 123.86
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -8,6 +9,7 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Swm
   hint: Er enghraifft, 123.86
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -15,6 +17,7 @@ rti-payslip-income-tax:
 rti-p60-payment-for-year:
   label: Swm
   hint: Er enghraifft, 21350.75
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -22,18 +25,21 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   label: Swm
   hint: Er enghraifft, 24368
+  prefix: £
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-postgraduate-loan-deductions:
   label: Swm
   hint: For example, 765
+  prefix: £
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-statutory-shared-parental-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -41,6 +47,7 @@ rti-p60-statutory-shared-parental-pay:
 rti-p60-statutory-adoption-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -48,6 +55,7 @@ rti-p60-statutory-adoption-pay:
 rti-p60-statutory-maternity-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -55,12 +63,14 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   label: Swm
   hint: Er enghraifft, 765
+  prefix: £
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
 rti-p60-employee-ni-contributions:
   label: Swm
   hint: Er enghraifft, 836.16
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -68,6 +78,7 @@ rti-p60-employee-ni-contributions:
 ita-bankaccount:
   label: 4 digid olaf o rif eich cyfrif
   hint: ""
+  prefix: ""
   validation:
     default: Rhowch y 4 digid olaf o rif eich cyfrif
     numeric: Rhaid i'r 4 digid olaf o rif eich cyfrif gynnwys rhifau yn unig
@@ -160,6 +171,7 @@ statePensionAndBenefitsShort:
 tc-amount:
   label: Swm
   hint: Er enghraifft, 36.75
+  prefix: £
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -172,6 +184,7 @@ selfAssessmentPaymentDate:
 selfAssessmentPaymentAmount:
   label: Swm y taliad
   hint: Rhowch y swm mewn punnoedd a cheiniogau. Er enghraifft, 3625.75.
+  prefix: £
   content: ""
   validation:
     required: Rhowch swm

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,6 +1,7 @@
 rti-payslip-national-insurance:
   label: Amount
   hint: For example 123.86
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -8,6 +9,7 @@ rti-payslip-national-insurance:
 rti-payslip-income-tax:
   label: Amount
   hint: For example 123.86
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -15,6 +17,7 @@ rti-payslip-income-tax:
 rti-p60-payment-for-year:
   label: Amount
   hint: For example, 21350.75
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -22,18 +25,21 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   label: Amount
   hint: For example, 24368
+  prefix: £
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
 rti-p60-postgraduate-loan-deductions:
   label: Amount
   hint: For example, 765
+  prefix: £
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
 rti-p60-statutory-shared-parental-pay:
   label: Amount
   hint: For example, 15620.75
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -41,6 +47,7 @@ rti-p60-statutory-shared-parental-pay:
 rti-p60-statutory-adoption-pay:
   label: Amount
   hint: For example, 15620.75
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -48,6 +55,7 @@ rti-p60-statutory-adoption-pay:
 rti-p60-statutory-maternity-pay:
   label: Amount
   hint: For example, 15620.75
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -55,12 +63,14 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   label: Amount
   hint: For example, 765
+  prefix: £
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
 rti-p60-employee-ni-contributions:
   label: Amount
   hint: For example, 836.16
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -68,6 +78,7 @@ rti-p60-employee-ni-contributions:
 ita-bankaccount:
   label: Last 4 digits of your account number
   hint: ""
+  prefix: ""
   validation:
     default: Enter the last 4 digits of your account number
     numeric: Last 4 digits of your account number must only include numbers
@@ -160,6 +171,7 @@ statePensionAndBenefitsShort:
 tc-amount:
   label: Amount
   hint: For example 36.75
+  prefix: £
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -172,6 +184,7 @@ selfAssessmentPaymentDate:
 selfAssessmentPaymentAmount:
   label: Payment amount
   hint: Enter the amount in pounds and pence. For example, 3625.75.
+  prefix: £
   content: ""
   validation:
     required: Enter an amount

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -38,9 +38,6 @@
       hint: {
         text: question.hint
       },
-      prefix: {
-        text: question.prefix
-      },
       classes: "govuk-input--width-5"
     }) }}
 


### PR DESCRIPTION
## Proposed changes

### What changed

Define the £ prefix at the field level and explicitly set "" for fields where we don't want the prefix to display

### Why did it change

This gets around the issue of the prefix always displaying (for which we've raised a PR in hmpo-components: https://github.com/HMPO/hmpo-components/pull/165) so we have a workaround in place while waiting for the PR to be merged and released

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6421](https://govukverify.atlassian.net/browse/PYIC-6421)



[PYIC-6421]: https://govukverify.atlassian.net/browse/PYIC-6421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ