### PR TITLE
PYIC-5182: Validation - Self assessment question page in pounds only 

### DIFF
--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -5,7 +5,7 @@ const {
 } = require("./fieldsHelper");
 const constants = require("../../constants/question-keys");
 
-const amountFieldValidateRequiredAndAmountWithDecimals = {
+const validateRequiredAmountWithPoundsAndPence = {
   type: "text",
   validate: [
     "required",
@@ -21,60 +21,43 @@ const amountFieldValidateRequiredAndAmountWithDecimals = {
   classes: "govuk-input--width-5",
 };
 
+const validateRequiredAmountWithPounds = {
+  type: "text",
+  validate: [
+    "required",
+    {
+      type: "regex",
+      arguments: [numericWithOptionalDecimalZeros],
+    },
+  ],
+  classes: "govuk-input--width-5",
+  stripDecimal: true,
+};
+
 module.exports = {
   [constants.ITA_BANKACCOUNT]: {
     type: "text",
     journeyKey: "itabankaccount",
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
   },
-  [constants.RTI_P60_EARNINGS_ABOVE_PT]: {
-    type: "text",
-    validate: [
-      "required",
-      {
-        type: "regex",
-        arguments: [numericWithOptionalDecimalZeros],
-      },
-    ],
-    stripDecimal: true,
-  },
-  [constants.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS]: {
-    type: "text",
-    validate: [
-      "required",
-      {
-        type: "regex",
-        arguments: [numericWithOptionalDecimalZeros],
-      },
-    ],
-    stripDecimal: true,
-  },
-  [constants.RTI_P60_STUDENT_LOAN_DEDUCTIONS]: {
-    type: "text",
-    validate: [
-      "required",
-      {
-        type: "regex",
-        arguments: [numericWithOptionalDecimalZeros],
-      },
-    ],
-    stripDecimal: true,
-  },
+  [constants.RTI_P60_EARNINGS_ABOVE_PT]: validateRequiredAmountWithPounds,
+  [constants.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS]:
+    validateRequiredAmountWithPounds,
+  [constants.RTI_P60_STUDENT_LOAN_DEDUCTIONS]: validateRequiredAmountWithPounds,
   [constants.RTI_P60_STATUTORY_MATERNITY_PAY]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
   [constants.RTI_PAYSLIP_NATIONAL_INSURANCE]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
-  [constants.RTI_PAYSLIP_INCOME_TAX]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
-  [constants.TC_AMOUNT]: amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
+  [constants.RTI_PAYSLIP_INCOME_TAX]: validateRequiredAmountWithPoundsAndPence,
+  [constants.TC_AMOUNT]: validateRequiredAmountWithPoundsAndPence,
   [constants.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
   [constants.RTI_P60_PAYMENT_FOR_YEAR]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
   [constants.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
   [constants.RTI_P60_STATUTORY_ADOPTION_PAY]:
-    amountFieldValidateRequiredAndAmountWithDecimals,
+    validateRequiredAmountWithPoundsAndPence,
   abandonRadio: {
     type: "radios",
     items: ["stop", "continue"],
@@ -85,59 +68,19 @@ module.exports = {
     items: ["sa100", "sa200"],
     validate: ["required"],
   },
-  statePension: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  otherPension: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  employmentAndSupportAllowance: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  jobSeekersAllowance: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  statePensionAndBenefits: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  statePensionShort: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  otherPensionShort: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  employmentAndSupportAllowanceShort: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  jobSeekersAllowanceShort: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
-  statePensionAndBenefitsShort: {
-    type: "text",
-    validate: ["required", "numeric"],
-    classes: "govuk-input--width-5",
-  },
+  statePension: validateRequiredAmountWithPounds,
+  otherPension: validateRequiredAmountWithPounds,
+  employmentAndSupportAllowance: validateRequiredAmountWithPounds,
+  jobSeekersAllowance: validateRequiredAmountWithPounds,
+  statePensionAndBenefits: validateRequiredAmountWithPounds,
+  statePensionShort: validateRequiredAmountWithPounds,
+  otherPensionShort: validateRequiredAmountWithPounds,
+  employmentAndSupportAllowanceShort: validateRequiredAmountWithPounds,
+  jobSeekersAllowanceShort: validateRequiredAmountWithPounds,
+  statePensionAndBenefitsShort: validateRequiredAmountWithPounds,
   selfAssessmentPaymentDate: {
     type: "date",
     validate: ["required", "date", { type: "before", arguments: [] }],
   },
-  selfAssessmentPaymentAmount: amountFieldValidateRequiredAndAmountWithDecimals,
+  selfAssessmentPaymentAmount: validateRequiredAmountWithPoundsAndPence,
 };

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -121,51 +121,81 @@ selfAssessmentRouter:
 statePension:
   label: Pensiwn y Wladwriaeth
   hint: Defnyddiwch blwch 8
+  validation:
+    default: Rhowch swm yn 'Pensiwn y Wladwriaeth'
+    regex: Rhowch rif cyfan, fel 123, yn 'Pensiwn y Wladwriaeth'
   prefix: £
   content: ""
 otherPension:
   label: Pensiynau (heblaw am Bensiynau y Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau
   hint: Defnyddiwch blwch 11
+  validation:
+    default: Rhowch swm yn 'Pensiynau (ac eithrio Pensiynau'r Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau'
+    regex: Rhowch rif cyfan, fel 123, yn 'Pensiynau (ac eithrio Pensiwn y Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau'
   prefix: £
   content: ""
 employmentAndSupportAllowance:
   label: Budd-dal Analluogrwydd trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau
   hint: Defnyddiwch blwch 13
+  validation:
+    required: Rhowch swm yn 'Budd-dal Analluogrwydd Trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau'
+    regex: Rhowch rif cyfan, fel 123, yn 'Budd-dal Analluogrwydd Trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau'
   prefix: £
   content: ""
 jobSeekersAllowance:
   label: Lwfans Ceisio Gwaith
   hint: Defnyddiwch blwch 15
+  validation:
+    default: Rhowch swm yn 'Lwfans Ceisio Gwaith'
+    regex: Rhowch rif cyfan, fel 123, yn 'Lwfans Ceisio Gwaith'
   prefix: £
   content: ""
 statePensionAndBenefits:
   label: Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill
   hint: Defnyddiwch blwch 16
+  validation:
+    default: Rhowch swm yn 'Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill'
+    regex: Rhowch rif cyfan, fel 123, yn 'Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill'
   prefix: £
   content: ""
 statePensionShort:
   label: Pensiwn y Wladwriaeth
   hint: Defnyddiwch blwch 4.1
+  validation:
+    default: Rhowch swm yn 'Pensiwn y Wladwriaeth'
+    regex: Rhowch rif cyfan, fel 123, yn 'Pensiwn y Wladwriaeth'
   prefix: £
   content: ""
 otherPensionShort:
   label: Pensiynau (heblaw am Bensiynau y Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau
   hint: Defnyddiwch blwch 4.2
+  validation:
+    default: Rhowch swm yn 'Pensiynau (ac eithrio Pensiynau'r Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau'
+    regex: Rhowch rif cyfan, fel 123, yn 'Pensiynau (ac eithrio Pensiwn y Wladwriaeth), blwydd-daliadau ymddeol a chyfandaliadau trethadwy sy'n cael eu trin fel pensiynau'
   prefix: £
   content: ""
 employmentAndSupportAllowanceShort:
   label: Budd-dal Analluogrwydd trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau
   hint: Defnyddiwch blwch 4.3
+  validation:
+    required: Rhowch swm yn 'Budd-dal Analluogrwydd Trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau'
+    regex: Rhowch rif cyfan, fel 123, yn 'Budd-dal Analluogrwydd Trethadwy a Lwfans Cyflogaeth a Chymorth yn seiliedig ar gyfraniadau'
   prefix: £
   content: ""
 jobSeekersAllowanceShort:
   label: Lwfans Ceisio Gwaith
   hint: Defnyddiwch blwch 4.5
+  validation:
+    default: Rhowch swm yn 'Lwfans Ceisio Gwaith'
+    regex: Rhowch rif cyfan, fel 123, yn 'Lwfans Ceisio Gwaith'
   prefix: £
   content: ""
 statePensionAndBenefitsShort:
   label: Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill
   hint: Defnyddiwch blwch 4.6
+  validation:
+    default: Rhowch swm yn 'Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill'
+    regex: Rhowch rif cyfan, fel 123, yn 'Cyfanswm unrhyw Bensiynau y Wladwriaeth a budd-daliadau trethadwy eraill'
   prefix: £
   content: ""
 tc-amount:

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -121,51 +121,81 @@ selfAssessmentRouter:
 statePension:
   label: State Pension
   hint: Use box 8
+  validation:
+    default: Enter an amount in 'State Pension'
+    regex: Enter a whole number, like 123, in 'State Pension'
   prefix: £
   content: ""
 otherPension:
   label: Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions
   hint: Use box 11
+  validation:
+    default: Enter an amount in 'Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions'
+    regex: Enter a whole number, like 123, in 'Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions'
   prefix: £
   content: ""
 employmentAndSupportAllowance:
   label: Taxable Incapacity Benefit and contribution-based Employment and Support Allowance
   hint: Use box 13
+  validation:
+    required: Enter an amount in 'Taxable Incapacity Benefit and contribution-based Employment and Support Allowance'
+    regex: Enter a whole number, like 123, in 'Taxable Incapacity Benefit and contribution-based Employment and Support Allowance'
   prefix: £
   content: ""
 jobSeekersAllowance:
   label: "Jobseeker's Allowance"
   hint: Use box 15
+  validation:
+    default: Enter an amount in 'Jobseeker's Allowance'
+    regex: Enter a whole number, like 123, in 'Jobseeker's Allowance'
   prefix: £
   content: ""
 statePensionAndBenefits:
   label: Total of any other taxable State Pensions and benefits
   hint: Use box 16
+  validation:
+    default: Enter an amount in 'Total of any other taxable State Pensions and benefits'
+    regex: Enter a whole number, like 123, in 'Total of any other taxable State Pensions and benefits'
   prefix: £
   content: ""
 statePensionShort:
   label: State Pension
   hint: Use box 4.1
+  validation:
+    default: Enter an amount in 'State Pension'
+    regex: Enter a whole number, like 123, in 'State Pension'
   prefix: £
   content: ""
 otherPensionShort:
   label: Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions
   hint: Use box 4.2
+  validation:
+    default: Enter an amount in 'Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions'
+    regex: Enter a whole number, like 123, in 'Pensions (other than State Pensions), retirement annuities and taxable lump sums treated as pensions'
   prefix: £
   content: ""
 employmentAndSupportAllowanceShort:
   label: Taxable Incapacity Benefit and contribution-based Employment and Support Allowance
   hint: Use box 4.3
+  validation:
+    required: Enter an amount in 'Taxable Incapacity Benefit and contribution-based Employment and Support Allowance'
+    regex: Enter a whole number, like 123, in 'Taxable Incapacity Benefit and contribution-based Employment and Support Allowance'
   prefix: £
   content: ""
 jobSeekersAllowanceShort:
   label: "Jobseeker's Allowance"
   hint: Use box 4.5
+  validation:
+    default: Enter an amount in 'Jobseeker's Allowance'
+    regex: Enter a whole number, like 123, in 'Jobseeker's Allowance'
   prefix: £
   content: ""
 statePensionAndBenefitsShort:
   label: Total of any other taxable State Pensions and benefits
   hint: Use box 4.6
+  validation:
+    default: Enter an amount in 'Total of any other taxable State Pensions and benefits'
+    regex: Enter a whole number, like 123, in 'Total of any other taxable State Pensions and benefits'
   prefix: £
   content: ""
 tc-amount:

--- a/tests/browser/features/validation.feature
+++ b/tests/browser/features/validation.feature
@@ -56,18 +56,42 @@ Feature: Validation scenarios
     When they enter amount "1234.45" and continue from the "enter-employees-contributions-p60" question page
     Then they should be redirected as a success
 
-  @mock-api:questions-selfAssessment @selfAssessment-journey
-  Scenario: Validation Path for selfAssessment-journey
-    Given Happy Harriet is using the system
-    And they have started the journey
-    Then they should see the answer security questions page
-    When they continue from answer security questions
-    Then they should see the what-type-self-assessment question page
-    When they select "sa200" and continue from the what-type-self-assessment question page
-    Then they should see the pensions-benefits-short-tax-return question page
-    When they enter correct pension details
-    Then they should see the enter-recent-self-assessment-payment question page
-    When they enter wrong self assessment payment details
-    Then they should see the enter-recent-self-assessment-payment question page with error
-    When they enter correct self assessment payment details
-    Then they should be redirected as a success
+@mock-api:questions-selfAssessment @selfAssessment-journey
+Scenario: Validation Path for selfAssessment-journey sa100
+  Given Happy Harriet is using the system
+  And they have started the journey
+  Then they should see the answer security questions page
+  When they continue from answer security questions
+  Then they should see the what-type-self-assessment question page
+  When they select "sa100" and continue from the what-type-self-assessment question page
+  Then they should see the pensions-benefits-self-assessment question page
+  When they enter empty pension details
+  Then they should see error messages
+  When they enter invalid pension details
+  Then they should see error messages
+  When they enter correct pension details
+  Then they should see the enter-recent-self-assessment-payment question page
+  When they enter wrong self assessment payment details
+  Then they should see the enter-recent-self-assessment-payment question page with error
+  When they enter correct self assessment payment details
+  Then they should be redirected as a success
+
+@mock-api:questions-selfAssessment @selfAssessment-journey
+Scenario: Validation Path for selfAssessment-journey sa200
+  Given Happy Harriet is using the system
+  And they have started the journey
+  Then they should see the answer security questions page
+  When they continue from answer security questions
+  Then they should see the what-type-self-assessment question page
+  When they select "sa200" and continue from the what-type-self-assessment question page
+  Then they should see the pensions-benefits-short-tax-return question page
+  When they enter empty pension details
+  Then they should see error messages
+  When they enter invalid pension details
+  Then they should see error messages
+  When they enter correct pension details
+  Then they should see the enter-recent-self-assessment-payment question page
+  When they enter wrong self assessment payment details
+  Then they should see the enter-recent-self-assessment-payment question page with error
+  When they enter correct self assessment payment details
+  Then they should be redirected as a success

--- a/tests/browser/pages/pensions-benefits-self-assessment.js
+++ b/tests/browser/pages/pensions-benefits-self-assessment.js
@@ -1,4 +1,4 @@
-module.exports = class PlaywrightDevPage {
+module.exports = class PensionsBenefitsSelfAssessmentPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
@@ -16,11 +16,19 @@ module.exports = class PlaywrightDevPage {
     return pathname === this.path;
   }
 
-  async answer() {
+  async answer(values = ["200", "200", "200", "200", "200"]) {
     await this.page.waitForSelector('input[type="text"]');
     const inputs = await this.page.$$('input[type="text"]');
-    for (let input of inputs) {
-      await input.fill("200");
+    for (let i = 0; i < inputs.length; i++) {
+      await inputs[i].fill(values[i]);
     }
+  }
+
+  async answerWithInvalidValues() {
+    await this.answer(["abc", "xyz", "123.45", "", "678.90"]);
+  }
+
+  async answerWithEmptyValues() {
+    await this.answer(["", "", "", "", ""]);
   }
 };

--- a/tests/browser/pages/pensions-benefits-short-tax-return.js
+++ b/tests/browser/pages/pensions-benefits-short-tax-return.js
@@ -1,4 +1,4 @@
-module.exports = class PlaywrightDevPage {
+module.exports = class PensionsBenefitsShortTaxReturnPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
@@ -14,5 +14,21 @@ module.exports = class PlaywrightDevPage {
   isCurrentPage() {
     const { pathname } = new URL(this.page.url());
     return pathname === this.path;
+  }
+
+  async answer(values = ["200", "200", "200", "200", "200"]) {
+    await this.page.waitForSelector('input[type="text"]');
+    const inputs = await this.page.$$('input[type="text"]');
+    for (let i = 0; i < inputs.length; i++) {
+      await inputs[i].fill(values[i]);
+    }
+  }
+
+  async answerWithInvalidValues() {
+    await this.answer(["abc", "xyz", "123.45", "", "678.90"]);
+  }
+
+  async answerWithEmptyValues() {
+    await this.answer(["", "", "", "", ""]);
   }
 };

--- a/tests/browser/step_definitions/pension-self-assessment.js
+++ b/tests/browser/step_definitions/pension-self-assessment.js
@@ -8,21 +8,58 @@ const { expect } = require("chai");
 Then(
   "they should see the pensions-benefits-self-assessment question page",
   async function () {
-    const pensionShortPage = new PensionsBenefitsSelfAssessmentPage(this.page);
-    expect(pensionShortPage.isCurrentPage()).to.be.true;
+    const page = new PensionsBenefitsSelfAssessmentPage(this.page);
+    expect(page.isCurrentPage()).to.be.true;
   }
 );
 
 Then(
   "they should see the pensions-benefits-short-tax-return question page",
   async function () {
-    const pensionShortPage = new PensionsBenefitsShortTaxReturnPage(this.page);
-    expect(pensionShortPage.isCurrentPage()).to.be.true;
+    const page = new PensionsBenefitsShortTaxReturnPage(this.page);
+    expect(page.isCurrentPage()).to.be.true;
   }
 );
 
 When("they enter correct pension details", async function () {
-  const pensionShortPage = new PensionsBenefitsSelfAssessmentPage(this.page);
-  await pensionShortPage.answer();
-  await pensionShortPage.continue();
+  const page = this.page
+    .url()
+    .includes("enter-pensions-benefits-short-tax-return")
+    ? new PensionsBenefitsShortTaxReturnPage(this.page)
+    : new PensionsBenefitsSelfAssessmentPage(this.page);
+
+  await page.answer();
+  await page.continue();
+});
+
+When("they enter invalid pension details", async function () {
+  const page = this.page
+    .url()
+    .includes("enter-pensions-benefits-short-tax-return")
+    ? new PensionsBenefitsShortTaxReturnPage(this.page)
+    : new PensionsBenefitsSelfAssessmentPage(this.page);
+
+  await page.answerWithInvalidValues();
+  await page.continue();
+});
+
+When("they enter empty pension details", async function () {
+  const page = this.page
+    .url()
+    .includes("enter-pensions-benefits-short-tax-return")
+    ? new PensionsBenefitsShortTaxReturnPage(this.page)
+    : new PensionsBenefitsSelfAssessmentPage(this.page);
+
+  await page.answerWithEmptyValues();
+  await page.continue();
+});
+
+Then("they should see error messages", async function () {
+  const page = this.page
+    .url()
+    .includes("enter-pensions-benefits-short-tax-return")
+    ? new PensionsBenefitsShortTaxReturnPage(this.page)
+    : new PensionsBenefitsSelfAssessmentPage(this.page);
+
+  expect(page.hasErrorSummary).to.not.be.false;
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The validation rules that must apply to each question set:
- User does not enter anything
- User enters disallowed characters
- Strip out spaces, should strip out the .00

Add error content with welsh translations

Add browser tests for Self Assessment validation

<img width="350" alt="Screenshot 2024-05-28 at 10 52 44" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/679aef98-71c3-4d79-8b0f-982f59c885ae">
<img width="350" alt="Screenshot 2024-05-28 at 10 53 20" src="https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/assets/24409958/a2f0336a-54ba-434c-ab83-d1a52e4c9ae0">


### Why did it change

As a user, 
I want to be guided through the KBV questions with clear validations in place, 
So that I can prove my identity without making mistakes

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-5182](https://govukverify.atlassian.net/browse/PYIC-5182)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-5182]: https://govukverify.atlassian.net/browse/PYIC-5182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ