### PR TITLE
PYIC-4915: Passing tax year(s) 

### DIFF
--- a/src/app/kbv/controllers/self-assessment-question.js
+++ b/src/app/kbv/controllers/self-assessment-question.js
@@ -12,8 +12,8 @@ class SelfAssessmentQuestionController extends BaseController {
       }
 
       locals = taxYearToRange(
-        req.session.question.info.currentTaxYear,
-        req.session.question.info.previousTaxYear
+        req.session.question?.info?.currentTaxYear,
+        req.session.question?.info?.previousTaxYear
       );
 
       callback(null, locals);

--- a/src/app/kbv/controllers/self-assessment-question.js
+++ b/src/app/kbv/controllers/self-assessment-question.js
@@ -11,7 +11,10 @@ class SelfAssessmentQuestionController extends BaseController {
         return callback(err, locals);
       }
 
-      locals.info = taxYearToRange(req.session.question.info.currentTaxYear);
+      locals = taxYearToRange(
+        req.session.question.info.currentTaxYear,
+        req.session.question.info.previousTaxYear
+      );
 
       callback(null, locals);
     });

--- a/src/app/kbv/controllers/self-assessment-router.js
+++ b/src/app/kbv/controllers/self-assessment-router.js
@@ -8,11 +8,7 @@ class SelfAssessmentRouterController extends BaseController {
         return callback(err, locals);
       }
 
-      const { yearRangeStart, yearRangeEnd } = taxYearToRange(
-        req.session.question?.info?.currentTaxYear
-      );
-      locals.yearRangeStart = yearRangeStart;
-      locals.yearRangeEnd = yearRangeEnd;
+      locals = taxYearToRange(req.session.question.info.currentTaxYear);
 
       callback(null, locals);
     });

--- a/src/app/kbv/controllers/self-assessment-router.js
+++ b/src/app/kbv/controllers/self-assessment-router.js
@@ -8,7 +8,7 @@ class SelfAssessmentRouterController extends BaseController {
         return callback(err, locals);
       }
 
-      locals = taxYearToRange(req.session.question.info.currentTaxYear);
+      locals = taxYearToRange(req.session.question?.info?.currentTaxYear);
 
       callback(null, locals);
     });

--- a/src/app/kbv/controllers/single-amount-question.js
+++ b/src/app/kbv/controllers/single-amount-question.js
@@ -4,6 +4,7 @@ const BaseController = require("hmpo-form-wizard").Controller;
 const presenters = require("../../../presenters");
 const { submitAnswer, getNextQuestion } = require("../service");
 const fields = require("../fieldsHelper");
+const taxYearToRange = require("../../../utils/tax-year-to-range");
 
 class SingleAmountQuestionController extends BaseController {
   configure(req, res, next) {
@@ -19,6 +20,11 @@ class SingleAmountQuestionController extends BaseController {
       if (err) {
         return callback(err, locals);
       }
+
+      locals = taxYearToRange(
+        req.session.question?.info?.currentTaxYear,
+        req.session.question?.info?.previousTaxYear
+      );
 
       locals.question = {
         label: presenters.questionToLabel(req.session.question, req.translate),

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -24,7 +24,6 @@ const amountFieldValidateRequiredAndAmountWithDecimals = {
 module.exports = {
   [constants.ITA_BANKACCOUNT]: {
     type: "text",
-    journeyKey: "itabankaccount",
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
   },
   [constants.RTI_P60_EARNINGS_ABOVE_PT]: {

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -41,6 +41,7 @@ module.exports = {
     next: "load-question",
   },
   "/question/enter-total-for-year-p60": {
+    backLink: null,
     controller: singleAmountQuestionController,
     fields: [constants.RTI_P60_PAYMENT_FOR_YEAR],
     next: "load-question",

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -2,6 +2,7 @@ rti-payslip-national-insurance:
   label: Swm
   hint: Er enghraifft, 123.86
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -10,6 +11,7 @@ rti-payslip-income-tax:
   label: Swm
   hint: Er enghraifft, 123.86
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -18,6 +20,7 @@ rti-p60-payment-for-year:
   label: Swm
   hint: Er enghraifft, 21350.75
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -26,6 +29,7 @@ rti-p60-earnings-above-pt:
   label: Swm
   hint: Er enghraifft, 24368
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
@@ -33,6 +37,7 @@ rti-p60-postgraduate-loan-deductions:
   label: Swm
   hint: For example, 765
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
@@ -40,6 +45,7 @@ rti-p60-statutory-shared-parental-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -48,6 +54,7 @@ rti-p60-statutory-adoption-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -56,6 +63,7 @@ rti-p60-statutory-maternity-pay:
   label: Swm
   hint: Er enghraifft, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -64,6 +72,7 @@ rti-p60-student-loan-deductions:
   label: Swm
   hint: Er enghraifft, 765
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regex: Rhaid i'r swm fod yn rhif cyfan, fel 123
@@ -71,6 +80,7 @@ rti-p60-employee-ni-contributions:
   label: Swm
   hint: Er enghraifft, 836.16
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45
@@ -79,6 +89,7 @@ ita-bankaccount:
   label: 4 digid olaf o rif eich cyfrif
   hint: ""
   prefix: ""
+  content: ""
   validation:
     default: Rhowch y 4 digid olaf o rif eich cyfrif
     numeric: Rhaid i'r 4 digid olaf o rif eich cyfrif gynnwys rhifau yn unig
@@ -172,6 +183,7 @@ tc-amount:
   label: Swm
   hint: Er enghraifft, 36.75
   prefix: £
+  content: ""
   validation:
     required: Rhowch swm
     regexNumeric: Rhowch swm dilys mewn punnoedd a cheiniogau, fel 123.45

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -42,30 +42,24 @@ rti-p60-payment-for-year:
   title: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
   h1: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘cyfanswm am y flwyddyn’. Byddwch yn dod o hyd i hyn yn yr adran ‘manylion cyflog a threth incwm’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
   details:
     summaryText: Os oes gennych fwy nag un P60
     html: >-
-      <p>Rhowch y swm yn y blwch wedi'i labelu ‘yn y gyflogaeth hon’.</p>
-      <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi. </p>
+      <p> Rhowch y swm yn y blwch wedi'i labelu ‘yn y gyflogaeth hon’. </p>
+      <p> Dim ond y swm o un P60 sydd angen i chi ei rhoi. </p>
 rti-p60-earnings-above-pt:
   title: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
   h1: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘enillion dros y PD, hyd at a chan gynnwys y Terfyn Enillion Uchaf (TEU)’. Byddwch yn dod o hyd i hyn yn yr adran ‘Cyfraniadau Yswiriant Gwladol yn y gyflogaeth hon’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -77,12 +71,9 @@ rti-p60-postgraduate-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
   h1: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn::"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘didyniadau benthyciad ôl-raddedig.’ Byddwch yn dod o hyd i hyn yn yr adran ‘manylion eraill’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -94,12 +85,9 @@ rti-p60-statutory-shared-parental-pay:
   title: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
   h1: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl statudol ar y cyd i rieni.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -111,12 +99,9 @@ rti-p60-statutory-adoption-pay:
   title: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
   h1: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl mabwysiadu statudol.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -128,12 +113,9 @@ rti-p60-statutory-maternity-pay:
   title: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
   h1: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl mamolaeth statudol.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -145,12 +127,9 @@ rti-p60-student-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
   h1: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘didyniadau benthyciad myfyriwr.’ Byddwch yn dod o hyd i hyn yn yr adran ‘manylion eraill’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -162,12 +141,9 @@ rti-p60-employee-ni-contributions:
   title: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
   h1: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
   inset:
-    html: >-
-      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
+    - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu 'cyfraniadau'r cyflogai sy'n ddyledus ar yr holl enillion dros y PD’. Byddwch yn dod o hyd i hyn yn yr adran ‘Cyfraniadau Yswiriant Gwladol yn y gyflogaeth hon’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -41,7 +41,8 @@ rti-payslip-income-tax:
 rti-p60-payment-for-year:
   title: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
   h1: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -56,7 +57,8 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   title: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
   h1: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -70,7 +72,8 @@ rti-p60-earnings-above-pt:
 rti-p60-postgraduate-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
   h1: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn::"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -84,7 +87,8 @@ rti-p60-postgraduate-loan-deductions:
 rti-p60-statutory-shared-parental-pay:
   title: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
   h1: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -98,7 +102,8 @@ rti-p60-statutory-shared-parental-pay:
 rti-p60-statutory-adoption-pay:
   title: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
   h1: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -112,7 +117,8 @@ rti-p60-statutory-adoption-pay:
 rti-p60-statutory-maternity-pay:
   title: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
   h1: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -126,7 +132,8 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
   h1: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"
@@ -140,7 +147,8 @@ rti-p60-student-loan-deductions:
 rti-p60-employee-ni-contributions:
   title: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
   h1: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
-  inset:
+  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }} ateb y cwestiwn hwn.
+  insetMultipleTaxYears:
     - "Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn:"
     - "{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -24,6 +24,7 @@ answer-security-questions:
   start-button: Dechrau
 rti-payslip-national-insurance:
   title: Rhowch swm yr Yswiriant Gwladol a dalwyd gennych o slip cyflog diweddar
+  h1: Rhowch swm yr Yswiriant Gwladol a dalwyd gennych o slip cyflog diweddar
   inset: Defnyddiwch slip cyflog wedi'i ddyddio ar ôl {{ dynamicDate }} i ateb y cwestiwn hwn
   content:
     - Dywedwch wrthym faint o Yswiriant Gwladol rydych wedi'i dalu.
@@ -31,6 +32,7 @@ rti-payslip-national-insurance:
     - Rhowch y swm mewn punnoedd a cheiniogau yn union fel y mae'n ymddangos ar eich slip cyflog.
 rti-payslip-income-tax:
   title: Rhowch faint o dreth a dalwyd gennych o slip cyflog diweddar
+  h1: Rhowch faint o dreth a dalwyd gennych o slip cyflog diweddar
   inset: Defnyddiwch slip cyflog wedi'i ddyddio ar ôl {{ dynamicDate }} i ateb y cwestiwn hwn
   content:
     - Dywedwch wrthym faint o Dreth Incwm rydych wedi'i dalu.
@@ -38,7 +40,14 @@ rti-payslip-income-tax:
     - Rhowch y swm mewn punnoedd a cheiniogau yn union fel y mae'n ymddangos ar eich slip cyflog.
 rti-p60-payment-for-year:
   title: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
-  inset: Defnyddiwch P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} i ateb y cwestiwn hwn.
+  h1: Rhowch y ‘cyfanswm am y flwyddyn’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘cyfanswm am y flwyddyn’. Byddwch yn dod o hyd i hyn yn yr adran ‘manylion cyflog a threth incwm’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -49,7 +58,14 @@ rti-p60-payment-for-year:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi. </p>
 rti-p60-earnings-above-pt:
   title: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm yr ‘enillion dros y PD’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘enillion dros y PD, hyd at a chan gynnwys y Terfyn Enillion Uchaf (TEU)’. Byddwch yn dod o hyd i hyn yn yr adran ‘Cyfraniadau Yswiriant Gwladol yn y gyflogaeth hon’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -59,7 +75,14 @@ rti-p60-earnings-above-pt:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-postgraduate-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm y ‘didyniadau benthyciad ôl-raddedig’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘didyniadau benthyciad ôl-raddedig.’ Byddwch yn dod o hyd i hyn yn yr adran ‘manylion eraill’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -69,7 +92,14 @@ rti-p60-postgraduate-loan-deductions:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-statutory-shared-parental-pay:
   title: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm y ‘tâl statudol ar y cyd i rieni’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl statudol ar y cyd i rieni.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -79,7 +109,14 @@ rti-p60-statutory-shared-parental-pay:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-statutory-adoption-pay:
   title: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm y ‘tâl mabwysiadu statudol’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl mabwysiadu statudol.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -89,7 +126,14 @@ rti-p60-statutory-adoption-pay:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-statutory-maternity-pay:
   title: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm y ‘tâl mamolaeth statudol’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘tâl mamolaeth statudol.’ Byddwch yn dod o hyd i hyn yn yr adran ‘taliadau statudol’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -99,7 +143,14 @@ rti-p60-statutory-maternity-pay:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-student-loan-deductions:
   title: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm y ‘didyniadau benthyciad myfyriwr’ o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu ‘didyniadau benthyciad myfyriwr.’ Byddwch yn dod o hyd i hyn yn yr adran ‘manylion eraill’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -109,7 +160,14 @@ rti-p60-student-loan-deductions:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 rti-p60-employee-ni-contributions:
   title: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
-  inset: Defnyddiwch eich P60 o'r flwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }} ateb y cwestiwn hwn.
+  h1: Rhowch swm 'cyfraniadau'r cyflogai' o'ch P60
+  inset:
+    html: >-
+      <p> Gallwch ddefnyddio P60 ar gyfer y naill un o'r blynyddoedd treth hyn: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Dywedwch wrthym y swm yn y blwch wedi'i labelu 'cyfraniadau'r cyflogai sy'n ddyledus ar yr holl enillion dros y PD’. Byddwch yn dod o hyd i hyn yn yr adran ‘Cyfraniadau Yswiriant Gwladol yn y gyflogaeth hon’ o'ch P60.
     - Rhowch y swm mewn punnoedd a cheiniogau, yn union fel mae'n ymddangos ar eich P60.
@@ -119,6 +177,7 @@ rti-p60-employee-ni-contributions:
       <p>Dim ond y swm o un P60 sydd angen i chi ei rhoi.</p>
 ita-bankaccount:
   title: Rhowch 4 digid olaf y cyfrif banc neu gymdeithas adeiladu y telir eich credydau treth iddo
+  h1: Rhowch 4 digid olaf y cyfrif banc neu gymdeithas adeiladu y telir eich credydau treth iddo
   content:
     - Gallwch chwilio am eich rhif cyfrif ar eich
     - - cerdyn banc
@@ -131,8 +190,8 @@ prove-identity-another-way:
   content: Efallai y gallwch brofi eich hunaniaeth mewn ffordd arall gyda GOV.UK One Login. Neu gallwch fynd yn ôl i'r gwasanaeth rydych angen ei ddefnyddio a gwirio a oes ffyrdd eraill o gael mynediad ato.
   warning: Ni allwch ddychwelyd i'r sgrin hon os ydych yn chwilio am ffordd arall o brofi eich hunaniaeth.
 questionWhatTypeSelfAssessment:
-  title: Pa fath o ffurflen dreth Hunanasesiad a anfonwyd gennych ar gyfer blwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }}?
-  h1: Pa fath o ffurflen dreth Hunanasesiad a anfonwyd gennych ar gyfer blwyddyn dreth {{ yearRangeStart }} i {{ yearRangeEnd }}?
+  title: Pa fath o ffurflen dreth Hunanasesiad a anfonwyd gennych ar gyfer blwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }}?
+  h1: Pa fath o ffurflen dreth Hunanasesiad a anfonwyd gennych ar gyfer blwyddyn dreth {{ currentYearRangeStart }} i {{ currentYearRangeEnd }}?
   content:
     - Mae hyn er mwyn i ni ofyn cwestiynau i chi am y ffurflen gywir.
     - Byddwch ond wedi anfon ffurflen dreth fer (SA200) os oedd CThEF wedi dweud wrthych am wneud hynny.
@@ -140,7 +199,7 @@ pensions-benefits-self-assessment:
   title: Rhowch symiau pensiynau a budd-daliadau o'ch Ffurflen dreth Hunanasesiad
   h1: Rhowch symiau pensiynau a budd-daliadau o'ch Ffurflen dreth Hunanasesiad
   content:
-    - <div class="govuk-inset-text"><p>I ateb y cwestiwn hwn, defnyddiwch eich Ffurflen dreth Hunanasesiad ar gyfer y naill flwyddyn dreth yma neu'r llall:</p><ul class="govuk-list govuk-list--bullet"><li>{{ info.yearRangeStart }} i {{ info.yearRangeEnd }}</li><li>{{ info.yearRangeStart }} i {{ info.yearRangeEnd }}</li></ul></div>
+    - <div class="govuk-inset-text"><p>I ateb y cwestiwn hwn, defnyddiwch eich Ffurflen dreth Hunanasesiad ar gyfer y naill flwyddyn dreth yma neu'r llall:</p><ul class="govuk-list govuk-list--bullet"><li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li><li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li></ul></div>
     - Dywedwch wrthym swm y pensiynau a budd-daliadau rydych yn eu derbyn.
     - Mae rhifau'r blychau ac enwau ar y dudalen hon yr un fath ag ar eich ffurflen dreth.
     - Rhowch y symiau mewn punnoedd heb y ceiniog, yn union fel maent yn ymddangos ar eich ffurflen dreth. Os yw'r blwch ar eich ffurflen dreth yn wag, rhowch 0.
@@ -148,12 +207,13 @@ pensions-benefits-short-tax-return:
   title: Rhowch symiau pensiynau a budd-daliadau o'ch ffurflen dreth fer
   h1: Rhowch symiau pensiynau a budd-daliadau o'ch ffurflen dreth fer
   content:
-    - <div class="govuk-inset-text"><p>I ateb y cwestiwn hwn, defnyddiwch eich ffurflen treth fer (SA200) ar gyfer naill flwyddyn dreth yma neu'r llall:</p><ul class="govuk-list govuk-list--bullet"><li>{{ info.yearRangeStart }} i {{ info.yearRangeEnd }}</li><li>{{ info.yearRangeStart }} i {{ info.yearRangeEnd }}</li></ul></div>
+    - <div class="govuk-inset-text"><p>I ateb y cwestiwn hwn, defnyddiwch eich ffurflen treth fer (SA200) ar gyfer naill flwyddyn dreth yma neu'r llall:</p><ul class="govuk-list govuk-list--bullet"><li>{{ currentYearRangeStart }} i {{ currentYearRangeEnd }}</li><li>{{ previousYearRangeStart }} i {{ previousYearRangeEnd }}</li></ul></div>
     - Dywedwch wrthym swm y pensiynau a budd-daliadau rydych yn eu derbyn.
     - Mae rhifau'r blychau ac enwau ar y dudalen hon yr un fath ag ar eich ffurflen dreth.
     - Rhowch y symiau mewn punnoedd heb y ceiniog, yn union fel maent yn ymddangos ar eich ffurflen dreth. Os yw'r blwch ar eich ffurflen dreth yn wag, rhowch 0.
 tc-amount:
   title: Rhowch swm taliad credydau treth diweddar
+  h1: Rhowch swm taliad credydau treth diweddar
   content:
     - Dywedwch wrthym am daliad credydau treth a gawsoch ar ôl {{ dynamicDate }}.
     - Byddwch yn cael taliadau credydau treth bob wythnos neu bob 4 wythnos. Dim ond swm un taliad sydd angen i chi ei roi

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -2,6 +2,7 @@ rti-payslip-national-insurance:
   label: Amount
   hint: For example 123.86
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -10,6 +11,7 @@ rti-payslip-income-tax:
   label: Amount
   hint: For example 123.86
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -18,6 +20,7 @@ rti-p60-payment-for-year:
   label: Amount
   hint: For example, 21350.75
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -26,6 +29,7 @@ rti-p60-earnings-above-pt:
   label: Amount
   hint: For example, 24368
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
@@ -33,6 +37,7 @@ rti-p60-postgraduate-loan-deductions:
   label: Amount
   hint: For example, 765
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
@@ -40,6 +45,7 @@ rti-p60-statutory-shared-parental-pay:
   label: Amount
   hint: For example, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -48,6 +54,7 @@ rti-p60-statutory-adoption-pay:
   label: Amount
   hint: For example, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -56,6 +63,7 @@ rti-p60-statutory-maternity-pay:
   label: Amount
   hint: For example, 15620.75
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -64,6 +72,7 @@ rti-p60-student-loan-deductions:
   label: Amount
   hint: For example, 765
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regex: Amount must be a whole number, like 123
@@ -71,6 +80,7 @@ rti-p60-employee-ni-contributions:
   label: Amount
   hint: For example, 836.16
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45
@@ -79,6 +89,7 @@ ita-bankaccount:
   label: Last 4 digits of your account number
   hint: ""
   prefix: ""
+  content: ""
   validation:
     default: Enter the last 4 digits of your account number
     numeric: Last 4 digits of your account number must only include numbers
@@ -172,6 +183,7 @@ tc-amount:
   label: Amount
   hint: For example 36.75
   prefix: £
+  content: ""
   validation:
     required: Enter an amount
     regexNumeric: Enter a valid amount in pounds and pence, like 123.45

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -24,6 +24,7 @@ answer-security-questions:
   start-button: Start
 rti-payslip-national-insurance:
   title: Enter the amount of National Insurance you paid from a recent payslip
+  h1: Enter the amount of National Insurance you paid from a recent payslip
   inset: Use a payslip dated after {{ dynamicDate }} to answer this question
   content:
     - Tell us the amount of National Insurance you paid.
@@ -31,6 +32,7 @@ rti-payslip-national-insurance:
     - Enter the amount in pounds and pence, exactly as it appears on your payslip.
 rti-payslip-income-tax:
   title: Enter the amount of Income Tax you paid from a recent payslip
+  h1: Enter the amount of Income Tax you paid from a recent payslip
   inset: Use a payslip dated after {{ dynamicDate }} to help you answer this question
   content:
     - Tell us the amount of Income Tax you paid.
@@ -38,7 +40,14 @@ rti-payslip-income-tax:
     - Enter the amount in pounds and pence, exactly as it appears on your payslip.
 rti-p60-payment-for-year:
   title: Enter the ‘total for year’ amount from your P60
-  inset: Use a P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘total for year’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘total for year’. You’ll find this in the ‘pay and income tax details’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -49,7 +58,14 @@ rti-p60-payment-for-year:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-earnings-above-pt:
   title: Enter the ‘earnings above the PT’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘earnings above the PT’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘earnings above the PT, up to and including the Upper Earnings Limit (UEL)’. You’ll find this in the ‘National Insurance contributions in this employment’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -59,7 +75,14 @@ rti-p60-earnings-above-pt:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-postgraduate-loan-deductions:
   title: Enter the ‘postgraduate loan deductions’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘postgraduate loan deductions’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘postgraduate loan deductions.’ You’ll find this in the ‘other details’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -69,7 +92,14 @@ rti-p60-postgraduate-loan-deductions:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-statutory-shared-parental-pay:
   title: Enter the ‘statutory shared parental pay’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘statutory shared parental pay’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘statutory shared parental pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -79,7 +109,14 @@ rti-p60-statutory-shared-parental-pay:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-statutory-adoption-pay:
   title: Enter the ‘statutory adoption pay’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘statutory adoption pay’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘statutory adoption pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -89,7 +126,14 @@ rti-p60-statutory-adoption-pay:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-statutory-maternity-pay:
   title: Enter the ‘statutory maternity pay’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘statutory maternity pay’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘statutory maternity pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -99,7 +143,14 @@ rti-p60-statutory-maternity-pay:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-student-loan-deductions:
   title: Enter the ‘student loan deductions’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘student loan deductions’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘student loan deductions.’ You’ll find this in the ‘other details’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -109,7 +160,14 @@ rti-p60-student-loan-deductions:
       <p>You only need to enter the amount from one P60.</p>
 rti-p60-employee-ni-contributions:
   title: Enter the ‘employee’s contributions’ amount from your P60
-  inset: Use your P60 from the tax year {{ yearRangeStart }} to {{ yearRangeEnd }} to answer this question.
+  h1: Enter the ‘employee’s contributions’ amount from your P60
+  inset:
+    html: >-
+      <p> Use can use a P60 from either of these tax years: <p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
+        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
+      </ul>
   content:
     - Tell us the amount in the box labelled ‘employee’s contributions due on all earnings above the PT’. You’ll find this in the ‘National Insurance contributions in this employment’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -119,6 +177,7 @@ rti-p60-employee-ni-contributions:
       <p>You only need to enter the amount from one P60.</p>
 ita-bankaccount:
   title: Enter the last 4 digits of the bank or building society account your tax credits are paid into
+  h1: Enter the last 4 digits of the bank or building society account your tax credits are paid into
   content:
     - "You can look for your account number on your:"
     - - bank card
@@ -131,8 +190,8 @@ prove-identity-another-way:
   content: You may be able to prove your identity another way with GOV.UK One Login. Or you can go back to the service you need to use and check if there are other ways to access it.
   warning: You cannot return to this screen if you look for another way to prove your identity.
 questionWhatTypeSelfAssessment:
-  title: What type of Self Assessment tax return did you send for the tax year {{ yearRangeStart }} to {{ yearRangeEnd }}?
-  h1: What type of Self Assessment tax return did you send for the tax year {{ yearRangeStart }} to {{ yearRangeEnd }}?
+  title: What type of Self Assessment tax return did you send for the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }}?
+  h1: What type of Self Assessment tax return did you send for the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }}?
   content:
     - This is so we can ask you questions about the right Self Assessment tax return.
     - You’ll only have sent a short tax return (SA200) if HMRC told you to.
@@ -140,7 +199,7 @@ pensions-benefits-self-assessment:
   title: Enter pensions and benefits amounts from your Self Assessment tax return
   h1: Enter pensions and benefits amounts from your Self Assessment tax return
   content:
-    - <div class="govuk-inset-text"><p>To answer this question, use your Self Assessment tax return for either of these tax years:</p><ul class="govuk-list govuk-list--bullet"><li>{{ info.yearRangeStart }} to {{ info.yearRangeEnd }}</li><li>{{ info.yearRangeStart }} to {{ info.yearRangeEnd }}</li></ul></div>
+    - <div class="govuk-inset-text"><p>To answer this question, use your Self Assessment tax return for either of these tax years:</p><ul class="govuk-list govuk-list--bullet"><li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li><li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li></ul></div>
     - Tell us the amount of pensions and benefits you received.
     - The box numbers and names on this page are the same as on your tax return.
     - Enter the amounts in pounds without the pence, exactly as they appear on your tax return. If the box in your tax return is empty, enter 0.
@@ -148,12 +207,13 @@ pensions-benefits-short-tax-return:
   title: Enter pensions and benefits amounts from your short tax return
   h1: Enter pensions and benefits amounts from your short tax return
   content:
-    - <div class="govuk-inset-text"><p>To answer this question, use your short tax return (SA200) for either of these tax years:</p><ul class="govuk-list govuk-list--bullet"><li>{{ info.yearRangeStart }} to {{ info.yearRangeEnd }}</li><li>{{ info.yearRangeStart }} to {{ info.yearRangeEnd }}</li></ul></div>
+    - <div class="govuk-inset-text"><p>To answer this question, use your short tax return (SA200) for either of these tax years:</p><ul class="govuk-list govuk-list--bullet"><li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li><li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li></ul></div>
     - Tell us the amounts you received in pensions and benefits.
     - The box numbers and names on this page are the same as on your tax return.
     - Enter the amounts in pounds without the pence, exactly as they appear on your tax return. If the box on your tax return is empty, enter 0.
 tc-amount:
   title: Enter a recent tax credits payment amount
+  h1: Enter a recent tax credits payment amount
   content:
     - Tell us about a tax credits payment you’ve had after {{ dynamicDate }}.
     - You’ll get tax credits payments every week or every 4 weeks. You only need to enter one payment amount.

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -41,7 +41,8 @@ rti-payslip-income-tax:
 rti-p60-payment-for-year:
   title: Enter the ‘total for year’ amount from your P60
   h1: Enter the ‘total for year’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -56,7 +57,8 @@ rti-p60-payment-for-year:
 rti-p60-earnings-above-pt:
   title: Enter the ‘earnings above the PT’ amount from your P60
   h1: Enter the ‘earnings above the PT’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -70,7 +72,8 @@ rti-p60-earnings-above-pt:
 rti-p60-postgraduate-loan-deductions:
   title: Enter the ‘postgraduate loan deductions’ amount from your P60
   h1: Enter the ‘postgraduate loan deductions’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -84,7 +87,8 @@ rti-p60-postgraduate-loan-deductions:
 rti-p60-statutory-shared-parental-pay:
   title: Enter the ‘statutory shared parental pay’ amount from your P60
   h1: Enter the ‘statutory shared parental pay’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -98,7 +102,8 @@ rti-p60-statutory-shared-parental-pay:
 rti-p60-statutory-adoption-pay:
   title: Enter the ‘statutory adoption pay’ amount from your P60
   h1: Enter the ‘statutory adoption pay’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -112,7 +117,8 @@ rti-p60-statutory-adoption-pay:
 rti-p60-statutory-maternity-pay:
   title: Enter the ‘statutory maternity pay’ amount from your P60
   h1: Enter the ‘statutory maternity pay’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -126,7 +132,8 @@ rti-p60-statutory-maternity-pay:
 rti-p60-student-loan-deductions:
   title: Enter the ‘student loan deductions’ amount from your P60
   h1: Enter the ‘student loan deductions’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
@@ -140,7 +147,8 @@ rti-p60-student-loan-deductions:
 rti-p60-employee-ni-contributions:
   title: Enter the ‘employee’s contributions’ amount from your P60
   h1: Enter the ‘employee’s contributions’ amount from your P60
-  inset:
+  inset: Use your P60 from the tax year {{ currentYearRangeStart }} to {{ currentYearRangeEnd }} to answer this question.
+  insetMultipleTaxYears:
     - "You can use a P60 from either of these tax years:"
     - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
     - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -42,12 +42,9 @@ rti-p60-payment-for-year:
   title: Enter the ‘total for year’ amount from your P60
   h1: Enter the ‘total for year’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘total for year’. You’ll find this in the ‘pay and income tax details’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -60,12 +57,9 @@ rti-p60-earnings-above-pt:
   title: Enter the ‘earnings above the PT’ amount from your P60
   h1: Enter the ‘earnings above the PT’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘earnings above the PT, up to and including the Upper Earnings Limit (UEL)’. You’ll find this in the ‘National Insurance contributions in this employment’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -77,12 +71,9 @@ rti-p60-postgraduate-loan-deductions:
   title: Enter the ‘postgraduate loan deductions’ amount from your P60
   h1: Enter the ‘postgraduate loan deductions’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘postgraduate loan deductions.’ You’ll find this in the ‘other details’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -94,12 +85,9 @@ rti-p60-statutory-shared-parental-pay:
   title: Enter the ‘statutory shared parental pay’ amount from your P60
   h1: Enter the ‘statutory shared parental pay’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘statutory shared parental pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -111,12 +99,9 @@ rti-p60-statutory-adoption-pay:
   title: Enter the ‘statutory adoption pay’ amount from your P60
   h1: Enter the ‘statutory adoption pay’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘statutory adoption pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -128,12 +113,9 @@ rti-p60-statutory-maternity-pay:
   title: Enter the ‘statutory maternity pay’ amount from your P60
   h1: Enter the ‘statutory maternity pay’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘statutory maternity pay.’ You’ll find this in the ‘statutory payments’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.
@@ -145,12 +127,9 @@ rti-p60-student-loan-deductions:
   title: Enter the ‘student loan deductions’ amount from your P60
   h1: Enter the ‘student loan deductions’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘student loan deductions.’ You’ll find this in the ‘other details’ section of your P60.
     - Enter the amount in pounds without the pence, exactly as it appears on your P60.
@@ -162,12 +141,9 @@ rti-p60-employee-ni-contributions:
   title: Enter the ‘employee’s contributions’ amount from your P60
   h1: Enter the ‘employee’s contributions’ amount from your P60
   inset:
-    html: >-
-      <p> Use can use a P60 from either of these tax years: <p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}</li>
-        <li>{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}</li>
-      </ul>
+    - "You can use a P60 from either of these tax years:"
+    - "{{ currentYearRangeStart }} to {{ currentYearRangeEnd }}"
+    - "{{ previousYearRangeStart }} to {{ previousYearRangeEnd }}"
   content:
     - Tell us the amount in the box labelled ‘employee’s contributions due on all earnings above the PT’. You’ll find this in the ‘National Insurance contributions in this employment’ section of your P60.
     - Enter the amount in pounds and pence, exactly as it appears on your P60.

--- a/src/presenters/question-to-content.js
+++ b/src/presenters/question-to-content.js
@@ -1,7 +1,7 @@
 const monthsAgoToDate = require("../utils/months-ago-to-date");
 
 module.exports = function (question, translate, language) {
-  const key = `fields.${question.questionKey}.content`;
+  const key = `pages.${question.questionKey}.content`;
   const data = {};
 
   if (question?.info?.months) {
@@ -14,5 +14,5 @@ module.exports = function (question, translate, language) {
     return content;
   }
 
-  return " ";
+  return "";
 };

--- a/src/presenters/question-to-details.js
+++ b/src/presenters/question-to-details.js
@@ -1,5 +1,5 @@
 module.exports = function (question, translate) {
-  const key = `fields.${question.questionKey}.details`;
+  const key = `pages.${question.questionKey}.details`;
   const details = translate(key);
 
   if (
@@ -11,5 +11,5 @@ module.exports = function (question, translate) {
     return details;
   }
 
-  return " ";
+  return "";
 };

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -2,22 +2,30 @@ const taxYearToRange = require("../utils/tax-year-to-range");
 const monthsAgoToDate = require("../utils/months-ago-to-date");
 
 module.exports = function (question, translate, language) {
-  const key = `fields.${question.questionKey}.inset`;
+  const key = `pages.${question.questionKey}.inset`;
   const data = {};
 
   if (question?.info?.months) {
     Object.assign(data, monthsAgoToDate(question?.info?.months, language));
   }
 
-  if (question?.info?.currentTaxYear) {
-    Object.assign(data, taxYearToRange(question?.info?.currentTaxYear));
+  if (question?.info?.currentTaxYear && question?.info?.previousTaxYear) {
+    Object.assign(
+      data,
+      taxYearToRange(
+        question.info.currentTaxYear,
+        question.info.previousTaxYear
+      )
+    );
+  } else if (question?.info?.currentTaxYear) {
+    Object.assign(data, taxYearToRange(question.info.currentTaxYear));
   }
 
   const inset = translate(key, data);
 
-  if (inset && !inset.includes(question.questionKey)) {
+  if (inset && typeof inset === "object" && "html" in inset) {
     return inset;
   }
 
-  return " ";
+  return "";
 };

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -9,7 +9,7 @@ module.exports = function (question, translate, language) {
     Object.assign(data, monthsAgoToDate(question?.info?.months, language));
   }
 
-  if (question?.info?.currentTaxYear && question?.info?.previousTaxYear) {
+  if (question?.info?.currentTaxYear) {
     Object.assign(
       data,
       taxYearToRange(
@@ -17,13 +17,11 @@ module.exports = function (question, translate, language) {
         question.info.previousTaxYear
       )
     );
-  } else if (question?.info?.currentTaxYear) {
-    Object.assign(data, taxYearToRange(question.info.currentTaxYear));
   }
 
   const inset = translate(key, data);
 
-  if (inset && typeof inset === "object" && "html" in inset) {
+  if (inset && !inset.includes(question.questionKey)) {
     return inset;
   }
 

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -2,7 +2,7 @@ const taxYearToRange = require("../utils/tax-year-to-range");
 const monthsAgoToDate = require("../utils/months-ago-to-date");
 
 module.exports = function (question, translate, language) {
-  const key = `pages.${question.questionKey}.inset`;
+  let key = "";
   const data = {};
 
   if (question?.info?.months) {
@@ -17,6 +17,12 @@ module.exports = function (question, translate, language) {
         question.info.previousTaxYear
       )
     );
+  }
+
+  if (question?.info?.previousTaxYear) {
+    key = `pages.${question.questionKey}.insetMultipleTaxYears`;
+  } else {
+    key = `pages.${question.questionKey}.inset`;
   }
 
   const inset = translate(key, data);

--- a/src/presenters/question-to-title.js
+++ b/src/presenters/question-to-title.js
@@ -1,5 +1,5 @@
 module.exports = function (question, translate) {
-  const key = `fields.${question.questionKey}.title`;
+  const key = `pages.${question.questionKey}.title`;
   const title = translate(key);
 
   if (title && !title.includes(question.questionKey)) {

--- a/src/utils/tax-year-to-range.js
+++ b/src/utils/tax-year-to-range.js
@@ -1,13 +1,30 @@
-module.exports = function (taxYear) {
+module.exports = function (currentTaxYear, previousTaxYear) {
   const data = {};
 
-  if (taxYear) {
-    const [startYear] = taxYear.split("/");
-    const yearRangeStart = parseInt(startYear, 10);
-    const yearRangeEnd = yearRangeStart + 1;
+  function processTaxYear(taxYear) {
+    if (taxYear) {
+      const [startYear] = taxYear.split("/");
+      const yearRangeStart = parseInt(startYear, 10);
+      const yearRangeEnd = yearRangeStart + 1;
 
-    data.yearRangeStart = yearRangeStart;
-    data.yearRangeEnd = yearRangeEnd;
+      return {
+        yearRangeStart: yearRangeStart,
+        yearRangeEnd: yearRangeEnd,
+      };
+    }
+    return null;
+  }
+
+  const currentData = processTaxYear(currentTaxYear);
+  if (currentData) {
+    data.currentYearRangeStart = currentData.yearRangeStart;
+    data.currentYearRangeEnd = currentData.yearRangeEnd;
+  }
+
+  const previousData = processTaxYear(previousTaxYear);
+  if (previousData) {
+    data.previousYearRangeStart = previousData.yearRangeStart;
+    data.previousYearRangeEnd = previousData.yearRangeEnd;
   }
 
   return data;

--- a/src/views/kbv/answer-security-questions.njk
+++ b/src/views/kbv/answer-security-questions.njk
@@ -4,12 +4,7 @@
 {% set hmpoPageKey = "answer-security-questions" %}
 {% set gtmJourney = "kbv-hmrc - start" %}
 
-{% block mainContentBody %}
-  {{ hmpoHtml(translate("pages.answer-security-questions.content")) }}
-  {{ hmpoDetails(translate("pages.answer-security-questions.details", { returnObjects: true}))}}
-{% endblock %}
-
 {% block submitButton %}
   {{ hmpoSubmit(ctx, {id: "start", text: translate("pages.answer-security-questions.start-button")}) }}
-  <p>{{ hmpoHtml(translate("pages.shared.abandon")) }}</p>
+  {{ hmpoHtml(translate("pages.shared.abandon")) }}
 {% endblock %}

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -7,9 +7,22 @@
   {% set gtmJourney = question.name + "- start" %}
 
   {% block mainContentBody %}
-    {% if question.details %}
-      {{ hmpoInsetText(question.inset) }}
-    {% endif %}
+
+  {% if question.inset %}
+    <div class="govuk-inset-text">
+      {% if currentYearRangeStart %}
+        <p>{{ question.inset[0] }}</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>{{ question.inset[1] }}</li>
+          {% if previousYearRangeStart %}
+            <li>{{ question.inset[2] }}</li>
+          {% endif %}
+        </ul>
+      {% else %}
+        <p>{{ question.inset }}</p>
+      {% endif %}
+    </div>
+  {% endif %}
 
     {{ hmpoHtml(question.content) }}
 

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -10,13 +10,11 @@
 
   {% if question.inset %}
     <div class="govuk-inset-text">
-      {% if currentYearRangeStart %}
+      {% if previousYearRangeStart %}
         <p>{{ question.inset[0] }}</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>{{ question.inset[1] }}</li>
-          {% if previousYearRangeStart %}
-            <li>{{ question.inset[2] }}</li>
-          {% endif %}
+          <li>{{ question.inset[2] }}</li>
         </ul>
       {% else %}
         <p>{{ question.inset }}</p>

--- a/src/views/kbv/single-amount-question.njk
+++ b/src/views/kbv/single-amount-question.njk
@@ -1,49 +1,24 @@
-{% extends "base-form.njk" %}
-{% from "hmpo-text/macro.njk" import hmpoText %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "hmpo-details/macro.njk" import hmpoDetails %}
+  {% extends "base-form.njk" %}
+  {% from "hmpo-text/macro.njk" import hmpoText %}
+  {% from "hmpo-details/macro.njk" import hmpoDetails %}
+  {% from "hmpo-inset-text/macro.njk" import hmpoInsetText %}
 
+  {% set hmpoPageKey = question.name %}
+  {% set gtmJourney = question.name + "- start" %}
 
-{% set gtmJourney = "kbv-hmrc - middle" %}
+  {% block mainContentBody %}
+    {% if question.details %}
+      {{ hmpoInsetText(question.inset) }}
+    {% endif %}
 
-{% set hmpoTitle = question.title %}
+    {{ hmpoHtml(question.content) }}
 
-{% block mainContent %}
-  <h1 class="govuk-heading-l"> {{ question.title }} </h1>
+    {% if question.details %}
+      {{ hmpoDetails(question.details) }}
+    {% endif %}
+  {% endblock %}
 
-  {% if question.inset != " " %}
-    {{ govukInsetText({
-      text: question.inset
-    }) }}
-  {% endif %}
-
-  {{ hmpoHtml(question.content) }}
-
-  {% if question.details != " " %}
-    {{ hmpoDetails({
-      summaryText: question.details.summaryText,
-      html: question.details.html
-    }) }}
-  {% endif %}
-
-  {% call hmpoForm(ctx) %}
-
-    {{ hmpoText(ctx, {
-      id: question.name,
-      name: question.name,
-      label: {
-        text: question.label,
-        classes: "govuk-label--m"
-      },
-      hint: {
-        text: question.hint
-      },
-      classes: "govuk-input--width-5"
-    }) }}
-
+  {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
-  {% endcall %}
-
-  {{ hmpoHtml(translate("pages.shared.abandon")) }}
-
-{% endblock %}
+    {{ hmpoHtml(translate("pages.shared.abandon")) }}
+  {% endblock %}

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -18,8 +18,7 @@
       {
         "questionKey": "rti-p60-payment-for-year",
         "info": {
-          "currentTaxYear": "2022/23",
-          "previousTaxYear": "2021/22"
+          "currentTaxYear": "2022/23"
         }
       },
       {
@@ -87,7 +86,8 @@
       {
         "questionKey": "sa-income-from-pensions",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -18,49 +18,57 @@
       {
         "questionKey": "rti-p60-payment-for-year",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-earnings-above-pt",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-postgraduate-loan-deductions",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-statutory-shared-parental-pay",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-statutory-adoption-pay",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-statutory-maternity-pay",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-student-loan-deductions",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       },
       {
         "questionKey": "rti-p60-employee-ni-contributions",
         "info": {
-          "currentTaxYear": "2022/23"
+          "currentTaxYear": "2022/23",
+          "previousTaxYear": "2021/22"
         }
       }
     ],

--- a/tests/unit/src/app/kbv/controllers/self-assessment.router.test.js
+++ b/tests/unit/src/app/kbv/controllers/self-assessment.router.test.js
@@ -35,15 +35,15 @@ describe("SelfAssessmentRouterController", () => {
     it("should set up locals object correctly", (done) => {
       const taxYearToRange = require("../../../../../../src/utils/tax-year-to-range");
       taxYearToRange.mockReturnValue({
-        yearRangeStart: 2023,
-        yearRangeEnd: 2024,
+        currnetYearRangeStart: 2023,
+        currentYearRangeEnd: 2024,
       });
 
       const callback = jest.fn((err, locals) => {
         expect(err).toBeNull();
         expect(locals).toBeDefined();
-        expect(locals.yearRangeStart).toBe(2023);
-        expect(locals.yearRangeEnd).toBe(2024);
+        expect(locals.currnetYearRangeStart).toBe(2023);
+        expect(locals.currentYearRangeEnd).toBe(2024);
         done();
       });
 

--- a/tests/unit/src/presenters/question-to-content.test.js
+++ b/tests/unit/src/presenters/question-to-content.test.js
@@ -20,7 +20,7 @@ describe("question-to-content", () => {
     presenters.questionToContent(question, translate, language);
 
     expect(translate).toHaveBeenCalledWith(
-      `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
       {}
     );
   });
@@ -47,7 +47,7 @@ describe("question-to-content", () => {
       presenters.questionToContent(question, translate, language);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
         { dynamicDate }
       );
     });
@@ -56,7 +56,7 @@ describe("question-to-content", () => {
       presenters.questionToContent(question, translate, language);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
         {}
       );
     });

--- a/tests/unit/src/presenters/question-to-details.test.js
+++ b/tests/unit/src/presenters/question-to-details.test.js
@@ -17,7 +17,7 @@ describe("question-to-details", () => {
     presenters.questionToDetails(question, translate);
 
     expect(translate).toHaveBeenCalledWith(
-      `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.details`
+      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.details`
     );
   });
 
@@ -42,7 +42,7 @@ describe("question-to-details", () => {
 
       const result = presenters.questionToDetails(question, translate);
 
-      expect(result).toBe(" ");
+      expect(result).toBe("");
     });
 
     it("should return an empty string if details are not in the expected format", () => {
@@ -53,7 +53,7 @@ describe("question-to-details", () => {
 
       const result = presenters.questionToDetails(question, translate);
 
-      expect(result).toBe(" ");
+      expect(result).toBe("");
     });
   });
 });

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -119,7 +119,7 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
         {
           currentYearRangeStart,
           currentYearRangeEnd,
@@ -189,6 +189,38 @@ describe("question-to-inset", () => {
     });
 
     it("should not include months information in the translated inset when months is not defined", () => {
+      question = {
+        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        info: {},
+      };
+
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        {}
+      );
+    });
+  });
+
+  describe("question-to-inset key based on previousTaxYear presence", () => {
+    it("should set key to include insetMultipleTaxYears when previousTaxYear is defined", () => {
+      question = {
+        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        info: {
+          previousTaxYear: "2021/22",
+        },
+      };
+
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
+        {}
+      );
+    });
+
+    it("should set key to include inset when previousTaxYear is not defined", () => {
       question = {
         questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {},

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -48,9 +48,9 @@ describe("question-to-inset", () => {
 
   describe("with translation key found", () => {
     it("should return english language translated content", () => {
-      translate.mockReturnValue({
-        html: `translated question inset three months ago ${englishDate}`,
-      });
+      translate.mockReturnValue(
+        `translated question inset three months ago ${englishDate}`
+      );
 
       const result = presenters.questionToInset(
         question,
@@ -63,15 +63,15 @@ describe("question-to-inset", () => {
         data
       );
 
-      expect(result).toEqual({
-        html: `translated question inset three months ago ${englishDate}`,
-      });
+      expect(result).toBe(
+        `translated question inset three months ago ${englishDate}`
+      );
     });
 
     it("should return welsh language translated content", () => {
-      translate.mockReturnValue({
-        html: `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`,
-      });
+      translate.mockReturnValue(
+        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
+      );
 
       const result = presenters.questionToInset(
         question,
@@ -86,9 +86,9 @@ describe("question-to-inset", () => {
         data
       );
 
-      expect(result).toEqual({
-        html: `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`,
-      });
+      expect(result).toBe(
+        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
+      );
     });
   });
 

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -30,7 +30,7 @@ describe("question-to-inset", () => {
     presenters.questionToInset(question, translate, englishLanguage);
 
     expect(translate).toHaveBeenCalledWith(
-      `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
       {}
     );
   });
@@ -43,14 +43,14 @@ describe("question-to-inset", () => {
       englishLanguage
     );
 
-    expect(insetTest).toBe(" ");
+    expect(insetTest).toBe("");
   });
 
   describe("with translation key found", () => {
     it("should return english language translated content", () => {
-      translate.mockReturnValue(
-        `translated question inset three months ago ${englishDate}`
-      );
+      translate.mockReturnValue({
+        html: `translated question inset three months ago ${englishDate}`,
+      });
 
       const result = presenters.questionToInset(
         question,
@@ -59,19 +59,19 @@ describe("question-to-inset", () => {
       );
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         data
       );
 
-      expect(result).toBe(
-        `translated question inset three months ago ${englishDate}`
-      );
+      expect(result).toEqual({
+        html: `translated question inset three months ago ${englishDate}`,
+      });
     });
 
     it("should return welsh language translated content", () => {
-      translate.mockReturnValue(
-        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
-      );
+      translate.mockReturnValue({
+        html: `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`,
+      });
 
       const result = presenters.questionToInset(
         question,
@@ -82,25 +82,54 @@ describe("question-to-inset", () => {
       data.dynamicDate = welshDate;
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         data
       );
 
-      expect(result).toBe(
-        `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`
-      );
+      expect(result).toEqual({
+        html: `mewnosod cwestiwn wedi'i gyfieithu dri mis yn ôl ${welshDate}`,
+      });
     });
   });
 
-  describe("question-to-inset with currentTaxYear", () => {
-    let question;
-    const englishLanguage = "en";
-
+  describe("question-to-inset with currentTaxYear and previousTaxYear", () => {
     beforeEach(() => {
       translate = jest.fn();
     });
 
-    it("should include tax year information in the translated inset when currentTaxYear is defined", () => {
+    it("should include tax year information in the translated inset when currentTaxYear and previousTaxYear are defined", () => {
+      question = {
+        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        info: {
+          currentTaxYear: "2022/23",
+          previousTaxYear: "2021/22",
+        },
+      };
+
+      const {
+        currentYearRangeStart,
+        currentYearRangeEnd,
+        previousYearRangeStart,
+        previousYearRangeEnd,
+      } = taxYearToRange(
+        question.info.currentTaxYear,
+        question.info.previousTaxYear
+      );
+
+      presenters.questionToInset(question, translate, englishLanguage);
+
+      expect(translate).toHaveBeenCalledWith(
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        {
+          currentYearRangeStart,
+          currentYearRangeEnd,
+          previousYearRangeStart,
+          previousYearRangeEnd,
+        }
+      );
+    });
+
+    it("should include tax year information in the translated inset when only currentTaxYear is defined", () => {
       question = {
         questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {
@@ -108,14 +137,18 @@ describe("question-to-inset", () => {
         },
       };
 
-      const { yearRangeStart, yearRangeEnd } = taxYearToRange(
-        question?.info?.currentTaxYear
+      const { currentYearRangeStart, currentYearRangeEnd } = taxYearToRange(
+        question.info.currentTaxYear
       );
+
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-        { yearRangeStart, yearRangeEnd }
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        {
+          currentYearRangeStart,
+          currentYearRangeEnd,
+        }
       );
     });
 
@@ -128,7 +161,7 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {}
       );
     });
@@ -144,13 +177,13 @@ describe("question-to-inset", () => {
       };
 
       const { dynamicDate } = monthsAgoToDate(
-        question?.info?.months,
+        question.info.months,
         englishLanguage
       );
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         { dynamicDate }
       );
     });
@@ -164,7 +197,7 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {}
       );
     });

--- a/tests/unit/src/presenters/question-to-title.test.js
+++ b/tests/unit/src/presenters/question-to-title.test.js
@@ -17,7 +17,7 @@ describe("question-to-title", () => {
     presenters.questionToTitle(question, translate);
 
     expect(translate).toHaveBeenCalledWith(
-      `fields.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.title`
+      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.title`
     );
   });
 

--- a/tests/unit/src/utils/tax-year-to-range.test.js
+++ b/tests/unit/src/utils/tax-year-to-range.test.js
@@ -5,31 +5,57 @@ Date.now = jest.fn(() => new Date("2024-05-01"));
 
 describe("tax-year-to-range", () => {
   let question;
-  const taxYear = "2022/23";
-  const yearRangeStart = 2022;
-  const yearRangeEnd = 2023;
+  const currentTaxYear = "2022/23";
+  const previousTaxYear = "2021/22";
+  const currentYearRangeStart = 2022;
+  const currentYearRangeEnd = 2023;
+  const previousYearRangeStart = 2021;
+  const previousYearRangeEnd = 2022;
 
   beforeEach(() => {
     question = {
       questionKey: constants.SA_INCOME_FROM_PENSIONS,
       info: {
-        currentTaxYear: taxYear,
+        currentTaxYear: currentTaxYear,
+        previousTaxYear: previousTaxYear,
       },
     };
   });
 
-  it("should return empty object when currentTaxYear is undefined", () => {
+  it("should return empty object when currentTaxYear and previousTaxYear are undefined", () => {
     question.info.currentTaxYear = undefined;
-    const result = taxYearToRange(question?.info?.currentTaxYear);
+    question.info.previousTaxYear = undefined;
+    const result = taxYearToRange(
+      question?.info?.currentTaxYear,
+      question?.info?.previousTaxYear
+    );
 
     expect(result).toEqual({});
   });
 
   describe("with currentTaxYear defined", () => {
-    it("should return object with yearRangeStart and yearRangeEnd when currentTaxYear is defined", () => {
-      const result = taxYearToRange(question?.info?.currentTaxYear);
+    it("should return object with currentYearRangeStart and currentYearRangeEnd when only currentTaxYear is defined", () => {
+      question.info.previousTaxYear = undefined;
+      const result = taxYearToRange(
+        question?.info?.currentTaxYear,
+        question?.info?.previousTaxYear
+      );
 
-      expect(result).toEqual({ yearRangeStart, yearRangeEnd });
+      expect(result).toEqual({ currentYearRangeStart, currentYearRangeEnd });
+    });
+
+    it("should return object with currentYearRangeStart, currentYearRangeEnd, previousYearRangeStart, and previousYearRangeEnd when both currentTaxYear and previousTaxYear are defined", () => {
+      const result = taxYearToRange(
+        question?.info?.currentTaxYear,
+        question?.info?.previousTaxYear
+      );
+
+      expect(result).toEqual({
+        currentYearRangeStart,
+        currentYearRangeEnd,
+        previousYearRangeStart,
+        previousYearRangeEnd,
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

From HMRC guidance, in some cases a user may be able to use their P60 from either of the previous two tax years (rather than only the previous tax year) to answer a question.

We will expect a back-end response with the 2 tax years:
```{
  "info": {
    "currentTaxYear": "2022/23",
    "previousTaxYear": "2021/22" // ** new **
  }
}
```
Added the ability to handle previousTaxYear, if this doesnt exist the existing fucntionality stays the same and it checks for only currentTaxYear
Aligned content to display the same across views as there was slight variations on how we was doing it
Added welsh translations for the updated content
Added test cases to cover new functionality

### Why did it change

As a user
I want to enter information from my P60 using the correct years
So that I can prove my identity

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-4915](https://govukverify.atlassian.net/browse/PYIC-4915)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-4915]: https://govukverify.atlassian.net/browse/PYIC-4915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ