### PR TITLE
BAU Use npm over yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:fix": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write",
     "build": "npm run build:sass && npm run build:js && npm run copy-assets",
-    "build:js": "yarn build:js:analytics && yarn build:js:all",
+    "build:js": "npm run build:js:analytics && npm run build:js:all",
     "build:js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/one-login-analytics/lib/analytics.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/init.js --beautify -o dist/public/javascripts/analytics.js",
     "build:js:all": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js node_modules/hmpo-components/all.js --beautify -o dist/public/javascripts/all.js",
     "minfiy-build-js": "uglifyjs src/assets/javascript/application.js -o src/assets/javascript/application.js -c -m && uglifyjs src/assets/javascript/cookies.js -o src/assets/javascript/cookies.js -c -m",


### PR DESCRIPTION
## Proposed changes

### What changed

BAU Use npm over yarn

### Why did it change

The build assets scripts were still using yarn but this repo should be using npm only now

