### PR TITLE
PYIC-6856 Call /fetchquestions at start of journey

### DIFF
--- a/src/app/kbv/controllers/start.js
+++ b/src/app/kbv/controllers/start.js
@@ -1,0 +1,31 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const {
+  API: {
+    PATHS: { FETCHQUESTIONS },
+  },
+} = require("../../../lib/config");
+
+class StartController extends BaseController {
+  async saveValues(req, res, next) {
+    // This call is to prime the questions set on the backend and ensure there are sufficient questions for this user
+    // Expect 2xx response if sufficient questions, allow to continue
+    // Expect non-2xx response if insufficient questions, let error bubble up to oauth callback
+    try {
+      await req.axios.post(
+        FETCHQUESTIONS,
+        {},
+        {
+          headers: {
+            "session-id": req.session.tokenId,
+            session_id: req.session.tokenId,
+          },
+        }
+      );
+      super.saveValues(req, res, () => next());
+    } catch (err) {
+      next(err);
+    }
+  }
+}
+
+module.exports = StartController;

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -1,3 +1,4 @@
+const startController = require("./controllers/start");
 const loadQuestionController = require("./controllers/load-question");
 const singleAmountQuestionController = require("./controllers/single-amount-question");
 const selfAssessmentRouterController = require("./controllers/self-assessment-router");
@@ -10,6 +11,7 @@ module.exports = {
     resetJourney: true,
     entryPoint: true,
     skip: true,
+    controller: startController,
     next: "answer-security-questions",
   },
   "/answer-security-questions": {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,6 +6,7 @@ module.exports = {
     PATHS: {
       SESSION: "session",
       AUTHORIZATION: "authorization",
+      FETCHQUESTIONS: "fetchquestions",
       QUESTION: "question",
       ANSWER: "answer",
     },

--- a/tests/browser/features/insufficient-questions.feature
+++ b/tests/browser/features/insufficient-questions.feature
@@ -1,0 +1,9 @@
+Feature: Insufficient questions
+
+  Insufficient questions when fetching questions at start of journey
+
+  @mock-api:insufficient-questions
+  Scenario: Insufficient questions
+    Given Error Eric is using the system
+    And they have started the journey
+    Then they should be redirected as an error with code invalid_request

--- a/tests/browser/step_definitions/relying-party.js
+++ b/tests/browser/step_definitions/relying-party.js
@@ -34,13 +34,16 @@ Then("they should be redirected as a success", function () {
   expect(rpPage.hasSuccessQueryParams()).to.be.true;
 });
 
-Then(/^the error should be (.*)$/, function (error_code) {
-  const rpPage = new RelyingPartyPage(this.page, this.TESTING_CLIENT_ID);
+Then(
+  /^they should be redirected as an error with code (.*)$/,
+  function (error_code) {
+    const rpPage = new RelyingPartyPage(this.page, this.TESTING_CLIENT_ID);
 
-  expect(rpPage.isRelyingPartyServer()).to.be.true;
+    expect(rpPage.isRelyingPartyServer()).to.be.true;
 
-  expect(rpPage.isErrorCode(error_code)).to.be.true;
-});
+    expect(rpPage.isErrorCode(error_code)).to.be.true;
+  }
+);
 
 When("they return to a previous page", async function () {
   const rpPage = new RelyingPartyPage(this.page, this.TESTING_CLIENT_ID);

--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -12,6 +12,37 @@ system:
       preloadFile: data/questions.json
 
 resources:
+  ### 'insufficient-questions' journey ###
+  - method: POST
+    path: /session
+    requestBody:
+      jsonPath: $.client_id
+      value: "insufficient-questions"
+    response:
+      statusCode: 201
+      template: true
+      content: |
+        {
+          "session_id": "insufficient-questions",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net"
+        }
+
+  - method: POST
+    path: /fetchquestions
+    requestHeaders:
+      session-id: insufficient-questions
+    response:
+      statusCode: 400
+      content: |
+        {
+          "redirect_uri": "http://example.net",
+          "oauth_error": {
+            "error_description": "Invalid request",
+            "error": "invalid_request"
+          }
+        }
+
   ### 'question-500' journey ###
   - method: GET
     path: /question
@@ -138,6 +169,15 @@ resources:
           "state": "sT@t3",
           "redirect_uri": "http://example.net"
         }
+
+  - method: POST
+    path: /fetchquestions
+    requestHeaders:
+      session-id:
+        value: "questions-.+-SEPARATOR-.+" # Match our session_id pattern
+        operator: Matches
+    response:
+      statusCode: 200
 
   - method: GET
     path: /question

--- a/tests/imposter/private-api.yaml
+++ b/tests/imposter/private-api.yaml
@@ -119,8 +119,8 @@ paths:
                 $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
               example:
                 oauth_error:
-                    error: "invalid_request"
-                    error_description: "Invalid request"
+                  error: "invalid_request"
+                  error_description: "Invalid request"
         "403":
           description: Session not found
           content:
@@ -129,8 +129,8 @@ paths:
                 $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
               example:
                 oauth_error:
-                    error: "access_denied"
-                    error_description: "Access denied"
+                  error: "access_denied"
+                  error_description: "Access denied"
         "500":
           description: Server error
           content:
@@ -145,8 +145,8 @@ paths:
                 $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
               example:
                 oauth_error:
-                    error: "server_error"
-                    error_description: "Unexpected server error"
+                  error: "server_error"
+                  error_description: "Unexpected server error"
 
   /question:
     get:

--- a/tests/imposter/private-api.yaml
+++ b/tests/imposter/private-api.yaml
@@ -90,6 +90,64 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /fetchquestions:
+    post:
+      description: >
+        Endpoint provided by the private api gateway, triggers the retrival of questions for the NINO supplied previously in the shared claims of the JWT.
+        Returns 200 if the matching NINO has sufficient questions,
+        else returns 400 with an oauth error containing invalid_request if there are not sufficient questions.
+      parameters:
+        - $ref: "#/components/parameters/SessionHeader"
+      requestBody:
+        content:
+          application/json: {}
+        required: false
+      responses:
+        "200":
+          description: There are sufficient questions
+          content:
+            application/json: {}
+        "204":
+          description: Request already retrieved, but continue the user has sufficient questions (User back button recovery path)
+          content:
+            application/json: {}
+        "400":
+          description: Insufficient questions for this NINO
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
+              example:
+                oauth_error:
+                    error: "invalid_request"
+                    error_description: "Invalid request"
+        "403":
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
+              example:
+                oauth_error:
+                    error: "access_denied"
+                    error_description: "Access denied"
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
+        "504":
+          description: Server error caused by a network issue with the remote api (Timeout/Unexpected Status Codes)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommmonExpressOauthAxiosError"
+              example:
+                oauth_error:
+                    error: "server_error"
+                    error_description: "Unexpected server error"
+
   /question:
     get:
       parameters:

--- a/tests/unit/src/app/kbv/controllers/start.test.js
+++ b/tests/unit/src/app/kbv/controllers/start.test.js
@@ -1,0 +1,67 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const Controller = require("../../../../../../src/app/kbv/controllers/start");
+const { FETCHQUESTIONS } = require("../../../../../../src/lib/config").API
+  .PATHS;
+
+jest.mock();
+describe("question controller", () => {
+  let controller;
+
+  beforeEach(() => {
+    controller = new Controller({ route: "/test" });
+  });
+
+  it("should be an instance of BaseController", () => {
+    controller = new Controller({ route: "/test" });
+
+    expect(controller).toBeInstanceOf(BaseController);
+  });
+
+  describe("#saveValues", () => {
+    const next = jest.fn();
+    const res = jest.fn();
+    let req;
+
+    beforeEach(() => {
+      req = global.req;
+    });
+
+    it("should call fetchquestions endpoint", async () => {
+      await controller.saveValues(req, res, next);
+
+      expect(req.axios.post).toHaveBeenCalledWith(
+        FETCHQUESTIONS,
+        {},
+        {
+          headers: {
+            "session-id": req.session.tokenId,
+            session_id: req.session.tokenId,
+          },
+        }
+      );
+    });
+
+    describe("when the user has sufficient questions and the endpoint returns a 2xx success response", () => {
+      it("should call next", async () => {
+        req.axios.post = jest.fn().mockResolvedValue({});
+
+        await controller.saveValues(req, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith();
+      });
+    });
+
+    describe("when the user has insufficient questions and the endpoint returns a 4xx error response", () => {
+      it("should call next with error", async () => {
+        const error = new Error("Async error message");
+        req.axios.post = jest.fn().mockRejectedValue(error);
+
+        await controller.saveValues(req, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenCalledWith(error);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

### What changed

Call the API `/fetchquestions` endpoint at the start of journey, on post of the root entry point which proceeds to the 'answer-security-questions' start page. Note this just adds the API call for now, but we will likely need to add a loading 'spinner' page pending UCD ([PYIC-4649](https://govukverify.atlassian.net/browse/PYIC-4649)).

### Why did it change

This call is required to prime the questions set on the backend and ensure there are sufficient questions for the provided NINO - if there are sufficient questions it will return a 2xx response and we can continue, if there are not it will return a 4xx error response with oauth code `invalid_request` which we should let bubble up to the error handler to be returned to the client.

### Issue tracking
- [PYIC-6856](https://govukverify.atlassian.net/browse/PYIC-6856)



[PYIC-4649]: https://govukverify.atlassian.net/browse/PYIC-4649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-6856]: https://govukverify.atlassian.net/browse/PYIC-6856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ