### PR TITLE
PYIC-6929: use total of pension fields for pensnion self assessment tax answer instead of json object

### DIFF
--- a/src/app/kbv/controllers/self-assessment-tax-return-question.js
+++ b/src/app/kbv/controllers/self-assessment-tax-return-question.js
@@ -27,7 +27,7 @@ class SelfAssessmentTaxReturnQuestionController extends BaseController {
       }
 
       try {
-        const userInput = JSON.stringify({
+        const pensionContributions = {
           statePension: req.body.statePension || req.body.statePensionShort,
           otherPension: req.body.otherPension || req.body.otherPensionShort,
           employmentAndSupportAllowance:
@@ -38,9 +38,19 @@ class SelfAssessmentTaxReturnQuestionController extends BaseController {
           statePensionAndBenefits:
             req.body.statePensionAndBenefits ||
             req.body.statePensionAndBenefitsShort,
-        });
+        };
 
-        await submitAnswer(req, constants.SA_INCOME_FROM_PENSIONS, userInput);
+        const totalPensionContribution = Object.keys(
+          pensionContributions
+        ).reduce(function (previous, key) {
+          return previous + parseFloat(pensionContributions[key] || 0);
+        }, 0);
+
+        await submitAnswer(
+          req,
+          constants.SA_INCOME_FROM_PENSIONS,
+          totalPensionContribution.toString()
+        );
 
         req.session.question = undefined;
         const nextQuestion = await getNextQuestion(req);

--- a/tests/unit/src/app/kbv/controllers/self-assessment-tax-return-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/self-assessment-tax-return-question.test.js
@@ -95,7 +95,7 @@ describe("self-assessment-question controller", () => {
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
           constants.SA_INCOME_FROM_PENSIONS,
-          JSON.stringify(req.body)
+          "160"
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });
@@ -106,27 +106,19 @@ describe("self-assessment-question controller", () => {
         req.body = {
           statePensionShort: 20,
           otherPensionShort: 20,
-          employmentAndSupportAllowanceShort: 30,
+          employmentAndSupportAllowanceShort: 50,
           jobSeekersAllowanceShort: 40,
           statePensionAndBenefitsShort: 50,
         };
         service.getNextQuestion.mockResolvedValue({});
         service.submitAnswer.mockResolvedValue({});
 
-        const apiRequestBody = {
-          statePension: 20,
-          otherPension: 20,
-          employmentAndSupportAllowance: 30,
-          jobSeekersAllowance: 40,
-          statePensionAndBenefits: 50,
-        };
-
         await controller.saveValues(req, res, next);
 
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
           constants.SA_INCOME_FROM_PENSIONS,
-          JSON.stringify(apiRequestBody)
+          "180"
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Use total of pension fields for pensnion self assessment tax answer instead of json object

### What changed

- Updated self assessment controller to use correct answer format.

<!-- Describe the changes in detail - the "what"-->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6929](https://govukverify.atlassian.net/browse/PYIC-6929)


[PYIC-6929]: https://govukverify.atlassian.net/browse/PYIC-6929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ