### PR TITLE
PYIC-6186: Extract fields and paths into constants

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 *.log
 node_modules
-tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/tests/unit/lib/helpers"],
   coveragePathIgnorePatterns: [
     "src/assets/.*",
+    "src/constants/.*",
     "src/app/.*/fields.js",
     "src/app/.*/steps.js",
     "src/app/.*/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.sources=src/
 sonar.exclusions=\
   src/**/*.test.js,\
   src/assets/**,\
+  src/constants/**,\
   src/app/**/fields.js,\
   src/app/**/steps.js,\
   src/app/**/index.js,\

--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -5,44 +5,44 @@ const {
     PATHS: { QUESTION },
   },
 } = require("../../../lib/config");
-const constants = require("../../../constants/question-keys");
+const questionKeys = require("../../../constants/question-keys");
 
 const questionKeyToPathMap = new Map([
   [
-    constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+    questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
     "enter-national-insurance-payslip",
   ],
-  [constants.RTI_PAYSLIP_INCOME_TAX, "enter-tax-payslip"],
-  [constants.ITA_BANKACCOUNT, "enter-4-digits-bank-account-tax-credits"],
-  [constants.RTI_P60_PAYMENT_FOR_YEAR, "enter-total-for-year-p60"],
-  [constants.RTI_P60_EARNINGS_ABOVE_PT, "enter-earnings-above-pt-p60"],
+  [questionKeys.RTI_PAYSLIP_INCOME_TAX, "enter-tax-payslip"],
+  [questionKeys.ITA_BANKACCOUNT, "enter-4-digits-bank-account-tax-credits"],
+  [questionKeys.RTI_P60_PAYMENT_FOR_YEAR, "enter-total-for-year-p60"],
+  [questionKeys.RTI_P60_EARNINGS_ABOVE_PT, "enter-earnings-above-pt-p60"],
   [
-    constants.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS,
+    questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS,
     "enter-postgraduate-loan-deductions-p60",
   ],
   [
-    constants.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY,
+    questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY,
     "enter-statutory-shared-parental-pay-p60",
   ],
   [
-    constants.RTI_P60_STATUTORY_ADOPTION_PAY,
+    questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY,
     "enter-statutory-adoption-pay-p60",
   ],
   [
-    constants.RTI_P60_STATUTORY_MATERNITY_PAY,
+    questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY,
     "enter-statutory-maternity-pay-p60",
   ],
   [
-    constants.RTI_P60_STUDENT_LOAN_DEDUCTIONS,
+    questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS,
     "enter-student-loan-deductions-p60",
   ],
   [
-    constants.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS,
+    questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS,
     "enter-employees-contributions-p60",
   ],
-  [constants.SA_INCOME_FROM_PENSIONS, "what-type-self-assessment"],
-  [constants.TC_AMOUNT, "enter-recent-tax-credits-payment"],
-  [constants.SA_PAYMENT_DETAILS, "enter-recent-self-assessment-payment"],
+  [questionKeys.SA_INCOME_FROM_PENSIONS, "what-type-self-assessment"],
+  [questionKeys.TC_AMOUNT, "enter-recent-tax-credits-payment"],
+  [questionKeys.SA_PAYMENT_DETAILS, "enter-recent-self-assessment-payment"],
 ]);
 
 class LoadQuestionController extends BaseController {

--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -6,43 +6,50 @@ const {
   },
 } = require("../../../lib/config");
 const questionKeys = require("../../../constants/question-keys");
+const routes = require("../../../constants/routes");
 
 const questionKeyToPathMap = new Map([
   [
     questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
-    "enter-national-insurance-payslip",
+    routes.ENTER_NATIONAL_INSURANCE_PAYSLIP,
   ],
-  [questionKeys.RTI_PAYSLIP_INCOME_TAX, "enter-tax-payslip"],
-  [questionKeys.ITA_BANKACCOUNT, "enter-4-digits-bank-account-tax-credits"],
-  [questionKeys.RTI_P60_PAYMENT_FOR_YEAR, "enter-total-for-year-p60"],
-  [questionKeys.RTI_P60_EARNINGS_ABOVE_PT, "enter-earnings-above-pt-p60"],
+  [questionKeys.RTI_PAYSLIP_INCOME_TAX, routes.ENTER_TAX_PAYSLIP],
+  [
+    questionKeys.ITA_BANKACCOUNT,
+    routes.ENTER_4_DIGITS_BANK_ACCOUNT_TAX_CREDITS,
+  ],
+  [questionKeys.RTI_P60_PAYMENT_FOR_YEAR, routes.ENTER_TOTAL_FOR_YEAR_P60],
+  [questionKeys.RTI_P60_EARNINGS_ABOVE_PT, routes.ENTER_EARNINGS_ABOVE_PT_P60],
   [
     questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS,
-    "enter-postgraduate-loan-deductions-p60",
+    routes.ENTER_POSTGRADUATE_LOAN_DEDUCTIONS_P60,
   ],
   [
     questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY,
-    "enter-statutory-shared-parental-pay-p60",
+    routes.ENTER_STATUTORY_SHARED_PARENTAL_PAY_P60,
   ],
   [
     questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY,
-    "enter-statutory-adoption-pay-p60",
+    routes.ENTER_STATUTORY_ADOPTION_PAY_P60,
   ],
   [
     questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY,
-    "enter-statutory-maternity-pay-p60",
+    routes.ENTER_STATUTORY_MATERNITY_PAY_P60,
   ],
   [
     questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS,
-    "enter-student-loan-deductions-p60",
+    routes.ENTER_STUDENT_LOAN_DEDUCTIONS_P60,
   ],
   [
     questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS,
-    "enter-employees-contributions-p60",
+    routes.ENTER_EMPLOYEES_CONTRIBUTIONS_P60,
   ],
-  [questionKeys.SA_INCOME_FROM_PENSIONS, "what-type-self-assessment"],
-  [questionKeys.TC_AMOUNT, "enter-recent-tax-credits-payment"],
-  [questionKeys.SA_PAYMENT_DETAILS, "enter-recent-self-assessment-payment"],
+  [questionKeys.SA_INCOME_FROM_PENSIONS, routes.WHAT_TYPE_SELF_ASSESSMENT],
+  [questionKeys.TC_AMOUNT, routes.ENTER_RECENT_TAX_CREDITS_PAYMENT],
+  [
+    questionKeys.SA_PAYMENT_DETAILS,
+    routes.ENTER_RECENT_SELF_ASSESSMENT_PAYMENT,
+  ],
 ]);
 
 class LoadQuestionController extends BaseController {

--- a/src/app/kbv/controllers/self-assessment-payment-question.js
+++ b/src/app/kbv/controllers/self-assessment-payment-question.js
@@ -1,7 +1,7 @@
 const debug = require("debug")("load-question");
 const BaseController = require("hmpo-form-wizard").Controller;
 const DateControllerMixin = require("hmpo-components").mixins.Date;
-const constants = require("../../../constants/question-keys");
+const questionKeys = require("../../../constants/question-keys");
 const { submitAnswer, getNextQuestion } = require("../service");
 
 const DateController = DateControllerMixin(BaseController);
@@ -20,7 +20,7 @@ class SelfAssessmentPaymentQuestionController extends DateController {
             req.form.values.selfAssessmentPaymentAmount,
         });
 
-        await submitAnswer(req, constants.SA_PAYMENT_DETAILS, userInput);
+        await submitAnswer(req, questionKeys.SA_PAYMENT_DETAILS, userInput);
 
         req.session.question = undefined;
         const nextQuestion = await getNextQuestion(req);

--- a/src/app/kbv/controllers/self-assessment-payment-question.js
+++ b/src/app/kbv/controllers/self-assessment-payment-question.js
@@ -2,6 +2,7 @@ const debug = require("debug")("load-question");
 const BaseController = require("hmpo-form-wizard").Controller;
 const DateControllerMixin = require("hmpo-components").mixins.Date;
 const questionKeys = require("../../../constants/question-keys");
+const fields = require("../../../constants/fields");
 const { submitAnswer, getNextQuestion } = require("../service");
 
 const DateController = DateControllerMixin(BaseController);
@@ -15,8 +16,9 @@ class SelfAssessmentPaymentQuestionController extends DateController {
 
       try {
         const userInput = JSON.stringify({
-          selfAssessmentPaymentDate: req.form.values.selfAssessmentPaymentDate,
-          selfAssessmentPaymentAmount:
+          [fields.SELF_ASSESSMENT_PAYMENT_DATE]:
+            req.form.values.selfAssessmentPaymentDate,
+          [fields.SELF_ASSESSMENT_PAYMENT_AMOUNT]:
             req.form.values.selfAssessmentPaymentAmount,
         });
 

--- a/src/app/kbv/controllers/self-assessment-tax-return-question.js
+++ b/src/app/kbv/controllers/self-assessment-tax-return-question.js
@@ -1,6 +1,7 @@
 const debug = require("debug")("load-question");
 const BaseController = require("hmpo-form-wizard").Controller;
-const constants = require("../../../constants/question-keys");
+const questionKeys = require("../../../constants/question-keys");
+const fields = require("../../../constants/fields");
 const { submitAnswer, getNextQuestion } = require("../service");
 const taxYearToRange = require("../../../utils/tax-year-to-range");
 
@@ -28,14 +29,16 @@ class SelfAssessmentTaxReturnQuestionController extends BaseController {
 
       try {
         const pensionContributions = {
-          statePension: req.body.statePension || req.body.statePensionShort,
-          otherPension: req.body.otherPension || req.body.otherPensionShort,
-          employmentAndSupportAllowance:
+          [fields.STATE_PENSION]:
+            req.body.statePension || req.body.statePensionShort,
+          [fields.OTHER_PENSION]:
+            req.body.otherPension || req.body.otherPensionShort,
+          [fields.EMPLOYMENT_AND_SUPPORT_ALLOWANCE]:
             req.body.employmentAndSupportAllowance ||
             req.body.employmentAndSupportAllowanceShort,
-          jobSeekersAllowance:
+          [fields.JOB_SEEKERS_ALLOWANCE]:
             req.body.jobSeekersAllowance || req.body.jobSeekersAllowanceShort,
-          statePensionAndBenefits:
+          [fields.STATE_PENSION_AND_BENEFITS]:
             req.body.statePensionAndBenefits ||
             req.body.statePensionAndBenefitsShort,
         };
@@ -48,7 +51,7 @@ class SelfAssessmentTaxReturnQuestionController extends BaseController {
 
         await submitAnswer(
           req,
-          constants.SA_INCOME_FROM_PENSIONS,
+          questionKeys.SA_INCOME_FROM_PENSIONS,
           totalPensionContribution.toString()
         );
 

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -42,12 +42,14 @@ module.exports = {
   [questionKeys.RTI_P60_EARNINGS_ABOVE_PT]: validateRequiredAmountWithPounds,
   [questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS]:
     validateRequiredAmountWithPounds,
-  [questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS]: validateRequiredAmountWithPounds,
+  [questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS]:
+    validateRequiredAmountWithPounds,
   [questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY]:
     validateRequiredAmountWithPoundsAndPence,
   [questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE]:
     validateRequiredAmountWithPoundsAndPence,
-  [questionKeys.RTI_PAYSLIP_INCOME_TAX]: validateRequiredAmountWithPoundsAndPence,
+  [questionKeys.RTI_PAYSLIP_INCOME_TAX]:
+    validateRequiredAmountWithPoundsAndPence,
   [questionKeys.TC_AMOUNT]: validateRequiredAmountWithPoundsAndPence,
   [questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS]:
     validateRequiredAmountWithPoundsAndPence,

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -3,7 +3,7 @@ const {
   numericWithOptionalDecimal,
   numericWithRequiredDecimals,
 } = require("./fieldsHelper");
-const constants = require("../../constants/question-keys");
+const questionKeys = require("../../constants/question-keys");
 
 const validateRequiredAmountWithPoundsAndPence = {
   type: "text",
@@ -35,27 +35,27 @@ const validateRequiredAmountWithPounds = {
 };
 
 module.exports = {
-  [constants.ITA_BANKACCOUNT]: {
+  [questionKeys.ITA_BANKACCOUNT]: {
     type: "text",
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
   },
-  [constants.RTI_P60_EARNINGS_ABOVE_PT]: validateRequiredAmountWithPounds,
-  [constants.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS]:
+  [questionKeys.RTI_P60_EARNINGS_ABOVE_PT]: validateRequiredAmountWithPounds,
+  [questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS]:
     validateRequiredAmountWithPounds,
-  [constants.RTI_P60_STUDENT_LOAN_DEDUCTIONS]: validateRequiredAmountWithPounds,
-  [constants.RTI_P60_STATUTORY_MATERNITY_PAY]:
+  [questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS]: validateRequiredAmountWithPounds,
+  [questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY]:
     validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_PAYSLIP_NATIONAL_INSURANCE]:
+  [questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE]:
     validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_PAYSLIP_INCOME_TAX]: validateRequiredAmountWithPoundsAndPence,
-  [constants.TC_AMOUNT]: validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS]:
+  [questionKeys.RTI_PAYSLIP_INCOME_TAX]: validateRequiredAmountWithPoundsAndPence,
+  [questionKeys.TC_AMOUNT]: validateRequiredAmountWithPoundsAndPence,
+  [questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS]:
     validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_P60_PAYMENT_FOR_YEAR]:
+  [questionKeys.RTI_P60_PAYMENT_FOR_YEAR]:
     validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY]:
+  [questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY]:
     validateRequiredAmountWithPoundsAndPence,
-  [constants.RTI_P60_STATUTORY_ADOPTION_PAY]:
+  [questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY]:
     validateRequiredAmountWithPoundsAndPence,
   abandonRadio: {
     type: "radios",

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -4,6 +4,7 @@ const {
   numericWithRequiredDecimals,
 } = require("./fieldsHelper");
 const questionKeys = require("../../constants/question-keys");
+const fields = require("../../constants/fields");
 
 const validateRequiredAmountWithPoundsAndPence = {
   type: "text",
@@ -59,29 +60,31 @@ module.exports = {
     validateRequiredAmountWithPoundsAndPence,
   [questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY]:
     validateRequiredAmountWithPoundsAndPence,
-  abandonRadio: {
+  [fields.ABANDON_RADIO]: {
     type: "radios",
     items: ["stop", "continue"],
     validate: ["required"],
   },
-  selfAssessmentRouter: {
+  [fields.SELF_ASSESSMENT_ROUTER]: {
     type: "radios",
     items: ["sa100", "sa200"],
     validate: ["required"],
   },
-  statePension: validateRequiredAmountWithPounds,
-  otherPension: validateRequiredAmountWithPounds,
-  employmentAndSupportAllowance: validateRequiredAmountWithPounds,
-  jobSeekersAllowance: validateRequiredAmountWithPounds,
-  statePensionAndBenefits: validateRequiredAmountWithPounds,
-  statePensionShort: validateRequiredAmountWithPounds,
-  otherPensionShort: validateRequiredAmountWithPounds,
-  employmentAndSupportAllowanceShort: validateRequiredAmountWithPounds,
-  jobSeekersAllowanceShort: validateRequiredAmountWithPounds,
-  statePensionAndBenefitsShort: validateRequiredAmountWithPounds,
-  selfAssessmentPaymentDate: {
+  [fields.STATE_PENSION]: validateRequiredAmountWithPounds,
+  [fields.OTHER_PENSION]: validateRequiredAmountWithPounds,
+  [fields.EMPLOYMENT_AND_SUPPORT_ALLOWANCE]: validateRequiredAmountWithPounds,
+  [fields.JOB_SEEKERS_ALLOWANCE]: validateRequiredAmountWithPounds,
+  [fields.STATE_PENSION_AND_BENEFITS]: validateRequiredAmountWithPounds,
+  [fields.STATE_PENSION_AND_BENEFITS_SHORT]: validateRequiredAmountWithPounds,
+  [fields.OTHER_PENSION_SHORT]: validateRequiredAmountWithPounds,
+  [fields.EMPLOYMENT_AND_SUPPORT_ALLOWANCE_SHORT]:
+    validateRequiredAmountWithPounds,
+  [fields.JOB_SEEKERS_ALLOWANCE_SHORT]: validateRequiredAmountWithPounds,
+  [fields.STATE_PENSION_AND_BENEFITS_SHORT]: validateRequiredAmountWithPounds,
+  [fields.SELF_ASSESSMENT_PAYMENT_DATE]: {
     type: "date",
     validate: ["required", "date", { type: "before", arguments: [] }],
   },
-  selfAssessmentPaymentAmount: validateRequiredAmountWithPoundsAndPence,
+  [fields.SELF_ASSESSMENT_PAYMENT_AMOUNT]:
+    validateRequiredAmountWithPoundsAndPence,
 };

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -4,7 +4,8 @@ const SingleInputQuestionController = require("./controllers/single-input-questi
 const selfAssessmentRouterController = require("./controllers/self-assessment-router");
 const SelfAssessmentTaxReturnQuestionController = require("./controllers/self-assessment-tax-return-question");
 const selfAssessmentPaymentQuestionController = require("./controllers/self-assessment-payment-question");
-const constants = require("../../constants/question-keys");
+const questionKeys = require("../../constants/question-keys");
+
 
 module.exports = {
   "/": {
@@ -32,72 +33,72 @@ module.exports = {
   "/question/enter-national-insurance-payslip": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_PAYSLIP_NATIONAL_INSURANCE],
+    fields: [questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE],
     next: "load-question",
   },
   "/question/enter-tax-payslip": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_PAYSLIP_INCOME_TAX],
+    fields: [questionKeys.RTI_PAYSLIP_INCOME_TAX],
     next: "load-question",
   },
   "/question/enter-total-for-year-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_PAYMENT_FOR_YEAR],
+    fields: [questionKeys.RTI_P60_PAYMENT_FOR_YEAR],
     next: "load-question",
   },
   "/question/enter-earnings-above-pt-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_EARNINGS_ABOVE_PT],
+    fields: [questionKeys.RTI_P60_EARNINGS_ABOVE_PT],
     next: "load-question",
   },
   "/question/enter-postgraduate-loan-deductions-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS],
+    fields: [questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS],
     next: "load-question",
   },
   "/question/enter-statutory-shared-parental-pay-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY],
+    fields: [questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY],
     next: "load-question",
   },
   "/question/enter-statutory-adoption-pay-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_STATUTORY_ADOPTION_PAY],
+    fields: [questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY],
     next: "load-question",
   },
   "/question/enter-statutory-maternity-pay-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_STATUTORY_MATERNITY_PAY],
+    fields: [questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY],
     next: "load-question",
   },
   "/question/enter-student-loan-deductions-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_STUDENT_LOAN_DEDUCTIONS],
+    fields: [questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS],
     next: "load-question",
   },
   "/question/enter-employees-contributions-p60": {
     backLink: null,
     controller: SingleInputQuestionController,
-    fields: [constants.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS],
+    fields: [questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS],
     next: "load-question",
   },
   "/question/enter-4-digits-bank-account-tax-credits": {
     backLink: null,
-    fields: [constants.ITA_BANKACCOUNT],
+    fields: [questionKeys.ITA_BANKACCOUNT],
     controller: SingleInputQuestionController,
     next: "load-question",
   },
   "/question/enter-recent-tax-credits-payment": {
     backLink: null,
-    fields: [constants.TC_AMOUNT],
+    fields: [questionKeys.TC_AMOUNT],
     controller: SingleInputQuestionController,
     next: "load-question",
   },

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -6,6 +6,7 @@ const SelfAssessmentTaxReturnQuestionController = require("./controllers/self-as
 const selfAssessmentPaymentQuestionController = require("./controllers/self-assessment-payment-question");
 const questionKeys = require("../../constants/question-keys");
 const routes = require("../../constants/routes");
+const fields = require("../../constants/fields");
 
 module.exports = {
   [routes.BASE_PATH]: {
@@ -109,16 +110,16 @@ module.exports = {
     template: "self-assessment-router",
     backLink: null,
     entryPoint: true,
-    fields: ["selfAssessmentRouter"],
+    fields: [fields.SELF_ASSESSMENT_ROUTER],
     controller: selfAssessmentRouterController,
     next: [
       {
-        field: "selfAssessmentRouter",
+        field: fields.SELF_ASSESSMENT_ROUTER,
         value: "sa100",
         next: `${routes.BASE_KBV_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SELF_ASSESSMENT}`,
       },
       {
-        field: "selfAssessmentRouter",
+        field: fields.SELF_ASSESSMENT_ROUTER,
         value: "sa200",
         next: `${routes.BASE_KBV_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN}`,
       },
@@ -129,11 +130,11 @@ module.exports = {
       backLink: null,
       template: "pensions-benefits-self-assessment",
       fields: [
-        "statePension",
-        "otherPension",
-        "employmentAndSupportAllowance",
-        "jobSeekersAllowance",
-        "statePensionAndBenefits",
+        fields.STATE_PENSION,
+        fields.OTHER_PENSION,
+        fields.EMPLOYMENT_AND_SUPPORT_ALLOWANCE,
+        fields.JOB_SEEKERS_ALLOWANCE,
+        fields.STATE_PENSION_AND_BENEFITS,
       ],
       controller: SelfAssessmentTaxReturnQuestionController,
       next: routes.LOAD_QUESTION,
@@ -143,11 +144,11 @@ module.exports = {
       backLink: null,
       template: "pensions-benefits-short-tax-return",
       fields: [
-        "statePensionShort",
-        "otherPensionShort",
-        "employmentAndSupportAllowanceShort",
-        "jobSeekersAllowanceShort",
-        "statePensionAndBenefitsShort",
+        fields.STATE_PENSION_SHORT,
+        fields.OTHER_PENSION_SHORT,
+        fields.EMPLOYMENT_AND_SUPPORT_ALLOWANCE_SHORT,
+        fields.JOB_SEEKERS_ALLOWANCE_SHORT,
+        fields.STATE_PENSION_AND_BENEFITS_SHORT,
       ],
       controller: SelfAssessmentTaxReturnQuestionController,
       next: routes.LOAD_QUESTION,
@@ -156,22 +157,22 @@ module.exports = {
     {
       backLink: null,
       template: "self-assessment-payment",
-      fields: ["selfAssessmentPaymentDate", "selfAssessmentPaymentAmount"],
+      fields: [fields.SELF_ASSESSMENT_PAYMENT_DATE, fields.SELF_ASSESSMENT_PAYMENT_AMOUNT],
       controller: selfAssessmentPaymentQuestionController,
       next: routes.LOAD_QUESTION,
     },
   [`${routes.BASE_PATH}${routes.PROVE_IDENTITY_ANOTHER_WAY}`]: {
     backLink: null,
     entryPoint: true,
-    fields: ["abandonRadio"],
+    fields: [fields.ABANDON_RADIO],
     next: [
       {
-        field: "abandonRadio",
+        field: fields.ABANDON_RADIO,
         value: "stop",
         next: "/oauth2/callback",
       },
       {
-        field: "abandonRadio",
+        field: fields.ABANDON_RADIO,
         value: "continue",
         next: [
           {

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -157,7 +157,10 @@ module.exports = {
     {
       backLink: null,
       template: "self-assessment-payment",
-      fields: [fields.SELF_ASSESSMENT_PAYMENT_DATE, fields.SELF_ASSESSMENT_PAYMENT_AMOUNT],
+      fields: [
+        fields.SELF_ASSESSMENT_PAYMENT_DATE,
+        fields.SELF_ASSESSMENT_PAYMENT_AMOUNT,
+      ],
       controller: selfAssessmentPaymentQuestionController,
       next: routes.LOAD_QUESTION,
     },

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -169,7 +169,7 @@ module.exports = {
       {
         field: fields.ABANDON_RADIO,
         value: "stop",
-        next: "/oauth2/callback",
+        next: routes.OAUTH2_CALLBACK_PATH,
       },
       {
         field: fields.ABANDON_RADIO,
@@ -187,6 +187,6 @@ module.exports = {
   [`${routes.BASE_PATH}${routes.DONE}`]: {
     skip: true,
     noPost: true,
-    next: "/oauth2/callback",
+    next: routes.OAUTH2_CALLBACK_PATH,
   },
 };

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -5,20 +5,20 @@ const selfAssessmentRouterController = require("./controllers/self-assessment-ro
 const SelfAssessmentTaxReturnQuestionController = require("./controllers/self-assessment-tax-return-question");
 const selfAssessmentPaymentQuestionController = require("./controllers/self-assessment-payment-question");
 const questionKeys = require("../../constants/question-keys");
-
+const routes = require("../../constants/routes");
 
 module.exports = {
-  "/": {
+  [routes.BASE_PATH]: {
     resetJourney: true,
     entryPoint: true,
     skip: true,
     controller: startController,
-    next: "answer-security-questions",
+    next: routes.ANSWER_SECURITY_QUESTIONS,
   },
-  "/answer-security-questions": {
-    next: "load-question",
+  [`${routes.BASE_PATH}${routes.ANSWER_SECURITY_QUESTIONS}`]: {
+    next: routes.LOAD_QUESTION,
   },
-  "/load-question": {
+  [`${routes.BASE_PATH}${routes.LOAD_QUESTION}`]: {
     backLink: null,
     controller: loadQuestionController,
     skip: true,
@@ -27,82 +27,85 @@ module.exports = {
         fn: loadQuestionController.prototype.hasQuestion,
         next: loadQuestionController.prototype.getQuestionPath,
       },
-      "done",
+      routes.DONE,
     ],
   },
-  "/question/enter-national-insurance-payslip": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_NATIONAL_INSURANCE_PAYSLIP}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-tax-payslip": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_TAX_PAYSLIP}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_PAYSLIP_INCOME_TAX],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-total-for-year-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_TOTAL_FOR_YEAR_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_PAYMENT_FOR_YEAR],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-earnings-above-pt-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_EARNINGS_ABOVE_PT_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_EARNINGS_ABOVE_PT],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-postgraduate-loan-deductions-p60": {
-    backLink: null,
-    controller: SingleInputQuestionController,
-    fields: [questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS],
-    next: "load-question",
-  },
-  "/question/enter-statutory-shared-parental-pay-p60": {
-    backLink: null,
-    controller: SingleInputQuestionController,
-    fields: [questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY],
-    next: "load-question",
-  },
-  "/question/enter-statutory-adoption-pay-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_POSTGRADUATE_LOAN_DEDUCTIONS_P60}`]:
+    {
+      backLink: null,
+      controller: SingleInputQuestionController,
+      fields: [questionKeys.RTI_P60_POSTGRADUATE_LOAN_DEDUCTIONS],
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_STATUTORY_SHARED_PARENTAL_PAY_P60}`]:
+    {
+      backLink: null,
+      controller: SingleInputQuestionController,
+      fields: [questionKeys.RTI_P60_STATUTORY_SHARED_PARENTAL_PAY],
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_STATUTORY_ADOPTION_PAY_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_STATUTORY_ADOPTION_PAY],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-statutory-maternity-pay-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_STATUTORY_MATERNITY_PAY_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_STATUTORY_MATERNITY_PAY],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-student-loan-deductions-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_STUDENT_LOAN_DEDUCTIONS_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_STUDENT_LOAN_DEDUCTIONS],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-employees-contributions-p60": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_EMPLOYEES_CONTRIBUTIONS_P60}`]: {
     backLink: null,
     controller: SingleInputQuestionController,
     fields: [questionKeys.RTI_P60_EMPLOYEE_NI_CONTRIBUTIONS],
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/enter-4-digits-bank-account-tax-credits": {
-    backLink: null,
-    fields: [questionKeys.ITA_BANKACCOUNT],
-    controller: SingleInputQuestionController,
-    next: "load-question",
-  },
-  "/question/enter-recent-tax-credits-payment": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_4_DIGITS_BANK_ACCOUNT_TAX_CREDITS}`]:
+    {
+      backLink: null,
+      fields: [questionKeys.ITA_BANKACCOUNT],
+      controller: SingleInputQuestionController,
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_RECENT_TAX_CREDITS_PAYMENT}`]: {
     backLink: null,
     fields: [questionKeys.TC_AMOUNT],
     controller: SingleInputQuestionController,
-    next: "load-question",
+    next: routes.LOAD_QUESTION,
   },
-  "/question/what-type-self-assessment": {
+  [`${routes.BASE_QUESTION_PATH}${routes.WHAT_TYPE_SELF_ASSESSMENT}`]: {
     template: "self-assessment-router",
     backLink: null,
     entryPoint: true,
@@ -112,49 +115,52 @@ module.exports = {
       {
         field: "selfAssessmentRouter",
         value: "sa100",
-        next: "/kbv/question/enter-pensions-benefits-self-assessment",
+        next: `${routes.BASE_KBV_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SELF_ASSESSMENT}`,
       },
       {
         field: "selfAssessmentRouter",
         value: "sa200",
-        next: "/kbv/question/enter-pensions-benefits-short-tax-return",
+        next: `${routes.BASE_KBV_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN}`,
       },
     ],
   },
-  "/question/enter-pensions-benefits-self-assessment": {
-    backLink: null,
-    template: "pensions-benefits-self-assessment",
-    fields: [
-      "statePension",
-      "otherPension",
-      "employmentAndSupportAllowance",
-      "jobSeekersAllowance",
-      "statePensionAndBenefits",
-    ],
-    controller: SelfAssessmentTaxReturnQuestionController,
-    next: "load-question",
-  },
-  "/question/enter-pensions-benefits-short-tax-return": {
-    backLink: null,
-    template: "pensions-benefits-short-tax-return",
-    fields: [
-      "statePensionShort",
-      "otherPensionShort",
-      "employmentAndSupportAllowanceShort",
-      "jobSeekersAllowanceShort",
-      "statePensionAndBenefitsShort",
-    ],
-    controller: SelfAssessmentTaxReturnQuestionController,
-    next: "load-question",
-  },
-  "/question/enter-recent-self-assessment-payment": {
-    backLink: null,
-    template: "self-assessment-payment",
-    fields: ["selfAssessmentPaymentDate", "selfAssessmentPaymentAmount"],
-    controller: selfAssessmentPaymentQuestionController,
-    next: "load-question",
-  },
-  "/prove-identity-another-way": {
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SELF_ASSESSMENT}`]:
+    {
+      backLink: null,
+      template: "pensions-benefits-self-assessment",
+      fields: [
+        "statePension",
+        "otherPension",
+        "employmentAndSupportAllowance",
+        "jobSeekersAllowance",
+        "statePensionAndBenefits",
+      ],
+      controller: SelfAssessmentTaxReturnQuestionController,
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN}`]:
+    {
+      backLink: null,
+      template: "pensions-benefits-short-tax-return",
+      fields: [
+        "statePensionShort",
+        "otherPensionShort",
+        "employmentAndSupportAllowanceShort",
+        "jobSeekersAllowanceShort",
+        "statePensionAndBenefitsShort",
+      ],
+      controller: SelfAssessmentTaxReturnQuestionController,
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_QUESTION_PATH}${routes.ENTER_RECENT_SELF_ASSESSMENT_PAYMENT}`]:
+    {
+      backLink: null,
+      template: "self-assessment-payment",
+      fields: ["selfAssessmentPaymentDate", "selfAssessmentPaymentAmount"],
+      controller: selfAssessmentPaymentQuestionController,
+      next: routes.LOAD_QUESTION,
+    },
+  [`${routes.BASE_PATH}${routes.PROVE_IDENTITY_ANOTHER_WAY}`]: {
     backLink: null,
     entryPoint: true,
     fields: ["abandonRadio"],
@@ -170,14 +176,14 @@ module.exports = {
         next: [
           {
             fn: loadQuestionController.prototype.hasQuestion,
-            next: "load-question",
+            next: routes.LOAD_QUESTION,
           },
-          "answer-security-questions",
+          routes.ANSWER_SECURITY_QUESTIONS,
         ],
       },
     ],
   },
-  "/done": {
+  [`${routes.BASE_PATH}${routes.DONE}`]: {
     skip: true,
     noPost: true,
     next: "/oauth2/callback",

--- a/src/constants/fields.js
+++ b/src/constants/fields.js
@@ -1,0 +1,16 @@
+module.exports = Object.freeze({
+  SELF_ASSESSMENT_ROUTER: "selfAssessmentRouter",
+  STATE_PENSION: "statePension",
+  OTHER_PENSION: "otherPension",
+  EMPLOYMENT_AND_SUPPORT_ALLOWANCE: "employmentAndSupportAllowance",
+  JOB_SEEKERS_ALLOWANCE: "jobSeekersAllowance",
+  STATE_PENSION_AND_BENEFITS: "statePensionAndBenefits",
+  STATE_PENSION_SHORT: "statePensionShort",
+  OTHER_PENSION_SHORT: "otherPensionShort",
+  EMPLOYMENT_AND_SUPPORT_ALLOWANCE_SHORT: "employmentAndSupportAllowanceShort",
+  JOB_SEEKERS_ALLOWANCE_SHORT: "jobSeekersAllowanceShort",
+  STATE_PENSION_AND_BENEFITS_SHORT: "statePensionAndBenefitsShort",
+  SELF_ASSESSMENT_PAYMENT_DATE: "selfAssessmentPaymentDate",
+  SELF_ASSESSMENT_PAYMENT_AMOUNT: "selfAssessmentPaymentAmount",
+  ABANDON_RADIO: "abandonRadio",
+});

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,31 @@
+module.exports = Object.freeze({
+  BASE_PATH: "/",
+  BASE_QUESTION_PATH: "/question/",
+  BASE_KBV_PATH: "/kbv/",
+  BASE_KBV_QUESTION_PATH: "/kbv/question/",
+  PROVE_IDENTITY_ANOTHER_WAY: "prove-identity-another-way",
+  DONE: "done",
+  ANSWER_SECURITY_QUESTIONS: "answer-security-questions",
+  LOAD_QUESTION: "load-question",
+  ENTER_NATIONAL_INSURANCE_PAYSLIP: "enter-national-insurance-payslip",
+  ENTER_TAX_PAYSLIP: "enter-tax-payslip",
+  ENTER_4_DIGITS_BANK_ACCOUNT_TAX_CREDITS:
+    "enter-4-digits-bank-account-tax-credits",
+  ENTER_TOTAL_FOR_YEAR_P60: "enter-total-for-year-p60",
+  ENTER_EARNINGS_ABOVE_PT_P60: "enter-earnings-above-pt-p60",
+  ENTER_POSTGRADUATE_LOAN_DEDUCTIONS_P60:
+    "enter-postgraduate-loan-deductions-p60",
+  ENTER_STATUTORY_SHARED_PARENTAL_PAY_P60:
+    "enter-statutory-shared-parental-pay-p60",
+  ENTER_STATUTORY_ADOPTION_PAY_P60: "enter-statutory-adoption-pay-p60",
+  ENTER_STATUTORY_MATERNITY_PAY_P60: "enter-statutory-maternity-pay-p60",
+  ENTER_STUDENT_LOAN_DEDUCTIONS_P60: "enter-student-loan-deductions-p60",
+  ENTER_EMPLOYEES_CONTRIBUTIONS_P60: "enter-employees-contributions-p60",
+  WHAT_TYPE_SELF_ASSESSMENT: "what-type-self-assessment",
+  ENTER_RECENT_TAX_CREDITS_PAYMENT: "enter-recent-tax-credits-payment",
+  ENTER_RECENT_SELF_ASSESSMENT_PAYMENT: "enter-recent-self-assessment-payment",
+  ENTER_PENSION_BENEFITS_SELF_ASSESSMENT:
+    "enter-pensions-benefits-self-assessment",
+  ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN:
+    "enter-pensions-benefits-short-tax-return",
+});

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -3,6 +3,7 @@ module.exports = Object.freeze({
   BASE_QUESTION_PATH: "/question/",
   BASE_KBV_PATH: "/kbv/",
   BASE_KBV_QUESTION_PATH: "/kbv/question/",
+  OAUTH2_CALLBACK_PATH: "/oauth2/callback",
   PROVE_IDENTITY_ANOTHER_WAY: "prove-identity-another-way",
   DONE: "done",
   ANSWER_SECURITY_QUESTIONS: "answer-security-questions",

--- a/tests/browser/Dockerfile
+++ b/tests/browser/Dockerfile
@@ -1,12 +1,13 @@
 FROM mcr.microsoft.com/playwright:v1.34.3-jammy as playwright
 
-WORKDIR /tests
+WORKDIR /app
+
+COPY . ./
+
+WORKDIR /app/tests
 
 COPY package.json package-lock.json ./
 
 RUN npm install
-
-COPY . ./
-
 
 CMD ["./run-tests.sh"]

--- a/tests/browser/Dockerfile
+++ b/tests/browser/Dockerfile
@@ -2,11 +2,9 @@ FROM mcr.microsoft.com/playwright:v1.34.3-jammy as playwright
 
 WORKDIR /app
 
-COPY . ./
+COPY . /app
 
-WORKDIR /app/tests
-
-COPY package.json package-lock.json ./
+WORKDIR /app/tests/browser
 
 RUN npm install
 

--- a/tests/browser/pages/answer-p60-questions.js
+++ b/tests/browser/pages/answer-p60-questions.js
@@ -1,4 +1,4 @@
-const { BASE_KBV_QUESTION_PATH } = require("../../../constants/routes");
+const { BASE_KBV_QUESTION_PATH } = require("../../../src/constants/routes");
 
 module.exports = class PlaywrightDevPage {
   /**

--- a/tests/browser/pages/answer-p60-questions.js
+++ b/tests/browser/pages/answer-p60-questions.js
@@ -1,4 +1,4 @@
-const { BASE_KBV_QUESTION_PATH } = require("../../../src/constants/routes");
+const { BASE_KBV_QUESTION_PATH } = require("../../../constants/routes");
 
 module.exports = class PlaywrightDevPage {
   /**

--- a/tests/browser/pages/answer-p60-questions.js
+++ b/tests/browser/pages/answer-p60-questions.js
@@ -1,10 +1,12 @@
+const { BASE_KBV_QUESTION_PATH } = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page, path) {
     this.page = page;
-    this.path = `/kbv/question/${path}`;
+    this.path = `${BASE_KBV_QUESTION_PATH}${path}`;
   }
 
   async continue() {

--- a/tests/browser/pages/answer-security-questions.js
+++ b/tests/browser/pages/answer-security-questions.js
@@ -1,10 +1,16 @@
+const {
+  BASE_KBV_PATH,
+  ANSWER_SECURITY_QUESTIONS,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
+
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/answer-security-questions";
+    this.path = `${BASE_KBV_PATH}${ANSWER_SECURITY_QUESTIONS}`;
   }
 
   async start() {

--- a/tests/browser/pages/enter-4-digits-bank-account-tax-credits.js
+++ b/tests/browser/pages/enter-4-digits-bank-account-tax-credits.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_4_DIGITS_BANK_ACCOUNT_TAX_CREDITS,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-4-digits-bank-account-tax-credits";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_4_DIGITS_BANK_ACCOUNT_TAX_CREDITS}`;
   }
 
   async continue() {

--- a/tests/browser/pages/enter-ni-payslip.js
+++ b/tests/browser/pages/enter-ni-payslip.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_NATIONAL_INSURANCE_PAYSLIP,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-national-insurance-payslip";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_NATIONAL_INSURANCE_PAYSLIP}`;
   }
 
   async continue() {

--- a/tests/browser/pages/enter-recent-self-assessment-payment.js
+++ b/tests/browser/pages/enter-recent-self-assessment-payment.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_RECENT_SELF_ASSESSMENT_PAYMENT,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-recent-self-assessment-payment";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_RECENT_SELF_ASSESSMENT_PAYMENT}`;
   }
 
   async continue() {

--- a/tests/browser/pages/enter-recent-tax-credits-payment.js
+++ b/tests/browser/pages/enter-recent-tax-credits-payment.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_RECENT_TAX_CREDITS_PAYMENT,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-recent-tax-credits-payment";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_RECENT_TAX_CREDITS_PAYMENT}`;
   }
 
   async continue() {

--- a/tests/browser/pages/enter-tax-payslip.js
+++ b/tests/browser/pages/enter-tax-payslip.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_TAX_PAYSLIP,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-tax-payslip";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_TAX_PAYSLIP}`;
   }
 
   async continue() {

--- a/tests/browser/pages/pensions-benefits-self-assessment.js
+++ b/tests/browser/pages/pensions-benefits-self-assessment.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_PENSION_BENEFITS_SELF_ASSESSMENT,
+} = require("../../../src/constants/routes");
+
 module.exports = class PensionsBenefitsSelfAssessmentPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-pensions-benefits-self-assessment";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_PENSION_BENEFITS_SELF_ASSESSMENT}`;
   }
 
   async continue() {

--- a/tests/browser/pages/pensions-benefits-short-tax-return.js
+++ b/tests/browser/pages/pensions-benefits-short-tax-return.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN,
+} = require("../../../src/constants/routes");
+
 module.exports = class PensionsBenefitsShortTaxReturnPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/enter-pensions-benefits-short-tax-return";
+    this.path = `${BASE_KBV_QUESTION_PATH}${ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN}`;
   }
 
   async continue() {

--- a/tests/browser/pages/prove-identity-another-way.js
+++ b/tests/browser/pages/prove-identity-another-way.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_PATH,
+  PROVE_IDENTITY_ANOTHER_WAY,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/prove-identity-another-way";
+    this.path = `${BASE_KBV_PATH}${PROVE_IDENTITY_ANOTHER_WAY}`;
   }
 
   async continue() {

--- a/tests/browser/pages/what-type-self-assessment.js
+++ b/tests/browser/pages/what-type-self-assessment.js
@@ -1,10 +1,15 @@
+const {
+  BASE_KBV_QUESTION_PATH,
+  WHAT_TYPE_SELF_ASSESSMENT,
+} = require("../../../src/constants/routes");
+
 module.exports = class PlaywrightDevPage {
   /**
    * @param {import('@playwright/test').Page} page
    */
   constructor(page) {
     this.page = page;
-    this.path = "/kbv/question/what-type-self-assessment";
+    this.path = `${BASE_KBV_QUESTION_PATH}${WHAT_TYPE_SELF_ASSESSMENT}`;
   }
 
   async continue() {

--- a/tests/browser/step_definitions/pension-self-assessment.js
+++ b/tests/browser/step_definitions/pension-self-assessment.js
@@ -4,6 +4,9 @@ const {
   PensionsBenefitsShortTaxReturnPage,
 } = require("../pages");
 const { expect } = require("chai");
+const {
+  ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN
+} = require("../../../src/constants/routes");
 
 Then(
   "they should see the pensions-benefits-self-assessment question page",
@@ -24,7 +27,7 @@ Then(
 When("they enter correct pension details", async function () {
   const page = this.page
     .url()
-    .includes("enter-pensions-benefits-short-tax-return")
+    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -35,7 +38,7 @@ When("they enter correct pension details", async function () {
 When("they enter invalid pension details", async function () {
   const page = this.page
     .url()
-    .includes("enter-pensions-benefits-short-tax-return")
+    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -46,7 +49,7 @@ When("they enter invalid pension details", async function () {
 When("they enter empty pension details", async function () {
   const page = this.page
     .url()
-    .includes("enter-pensions-benefits-short-tax-return")
+    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -57,7 +60,7 @@ When("they enter empty pension details", async function () {
 Then("they should see error messages", async function () {
   const page = this.page
     .url()
-    .includes("enter-pensions-benefits-short-tax-return")
+    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 

--- a/tests/browser/step_definitions/pension-self-assessment.js
+++ b/tests/browser/step_definitions/pension-self-assessment.js
@@ -5,7 +5,7 @@ const {
 } = require("../pages");
 const { expect } = require("chai");
 const {
-  ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN
+  ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN,
 } = require("../../../src/constants/routes");
 
 Then(
@@ -25,9 +25,7 @@ Then(
 );
 
 When("they enter correct pension details", async function () {
-  const page = this.page
-    .url()
-    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
+  const page = this.page.url().includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -36,9 +34,7 @@ When("they enter correct pension details", async function () {
 });
 
 When("they enter invalid pension details", async function () {
-  const page = this.page
-    .url()
-    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
+  const page = this.page.url().includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -47,9 +43,7 @@ When("they enter invalid pension details", async function () {
 });
 
 When("they enter empty pension details", async function () {
-  const page = this.page
-    .url()
-    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
+  const page = this.page.url().includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 
@@ -58,9 +52,7 @@ When("they enter empty pension details", async function () {
 });
 
 Then("they should see error messages", async function () {
-  const page = this.page
-    .url()
-    .includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
+  const page = this.page.url().includes(ENTER_PENSION_BENEFITS_SHORT_TAX_RETURN)
     ? new PensionsBenefitsShortTaxReturnPage(this.page)
     : new PensionsBenefitsSelfAssessmentPage(this.page);
 

--- a/tests/docker/compose.yml
+++ b/tests/docker/compose.yml
@@ -26,8 +26,8 @@ services:
 
   cucumber:
     build:
-      context: ../browser
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: tests/browser/Dockerfile
     environment:
       MOCK_API: true
       GITHUB_ACTIONS: true

--- a/tests/unit/src/app/kbv/controllers/load-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/load-question.test.js
@@ -4,7 +4,6 @@ const { QUESTION } = require("../../../../../../src/lib/config").API.PATHS;
 const questionKeys = require("../../../../../../src/constants/question-keys");
 const routes = require("../../../../../../src/constants/routes");
 
-
 jest.mock();
 describe("question controller", () => {
   let controller;
@@ -101,7 +100,9 @@ describe("question controller", () => {
 
       const result = controller.getQuestionPath(req);
 
-      expect(result).toBe(`question/${routes.ENTER_NATIONAL_INSURANCE_PAYSLIP}`);
+      expect(result).toBe(
+        `question/${routes.ENTER_NATIONAL_INSURANCE_PAYSLIP}`
+      );
     });
   });
 });

--- a/tests/unit/src/app/kbv/controllers/load-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/load-question.test.js
@@ -1,7 +1,7 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const Controller = require("../../../../../../src/app/kbv/controllers/load-question");
 const { QUESTION } = require("../../../../../../src/lib/config").API.PATHS;
-const constants = require("../../../../../../src/constants/question-keys");
+const questionKeys = require("../../../../../../src/constants/question-keys");
 
 jest.mock();
 describe("question controller", () => {
@@ -64,7 +64,7 @@ describe("question controller", () => {
     it('should return "true" when there is a next question', () => {
       const req = {
         session: {
-          question: { questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE },
+          question: { questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE },
         },
       };
 
@@ -89,7 +89,7 @@ describe("question controller", () => {
     it("should return path for the next question", () => {
       const req = {
         session: {
-          question: { questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE },
+          question: { questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE },
         },
       };
 

--- a/tests/unit/src/app/kbv/controllers/load-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/load-question.test.js
@@ -2,6 +2,8 @@ const BaseController = require("hmpo-form-wizard").Controller;
 const Controller = require("../../../../../../src/app/kbv/controllers/load-question");
 const { QUESTION } = require("../../../../../../src/lib/config").API.PATHS;
 const questionKeys = require("../../../../../../src/constants/question-keys");
+const routes = require("../../../../../../src/constants/routes");
+
 
 jest.mock();
 describe("question controller", () => {
@@ -64,7 +66,9 @@ describe("question controller", () => {
     it('should return "true" when there is a next question', () => {
       const req = {
         session: {
-          question: { questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE },
+          question: {
+            questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
+          },
         },
       };
 
@@ -89,13 +93,15 @@ describe("question controller", () => {
     it("should return path for the next question", () => {
       const req = {
         session: {
-          question: { questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE },
+          question: {
+            questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
+          },
         },
       };
 
       const result = controller.getQuestionPath(req);
 
-      expect(result).toBe("question/enter-national-insurance-payslip");
+      expect(result).toBe(`question/${routes.ENTER_NATIONAL_INSURANCE_PAYSLIP}`);
     });
   });
 });

--- a/tests/unit/src/app/kbv/controllers/self-assessment-payment-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/self-assessment-payment-question.test.js
@@ -1,7 +1,7 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const Controller = require("../../../../../../src/app/kbv/controllers/self-assessment-payment-question");
 const service = require("../../../../../../src/app/kbv/service");
-const constants = require("../../../../../../src/constants/question-keys");
+const questionKeys = require("../../../../../../src/constants/question-keys");
 jest.mock("../../../../../../src/app/kbv/service");
 
 describe("self-assessment-payment-question controller", () => {
@@ -39,7 +39,7 @@ describe("self-assessment-payment-question controller", () => {
 
     describe("on API success", () => {
       it("should call answer endpoint to post submitted answer", async () => {
-        const questionKey = constants.SA_PAYMENT_DETAILS;
+        const questionKey = questionKeys.SA_PAYMENT_DETAILS;
         req.session.question.questionKey = questionKey;
         req.form.values = {
           selfAssessmentPaymentDate: "2023-02-22",
@@ -52,17 +52,17 @@ describe("self-assessment-payment-question controller", () => {
 
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
-          constants.SA_PAYMENT_DETAILS,
+          questionKeys.SA_PAYMENT_DETAILS,
           JSON.stringify(req.form.values)
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });
 
       it("should call question endpoint to get next question and store it in session", async () => {
-        req.session.question.questionKey = constants.SA_PAYMENT_DETAILS;
+        req.session.question.questionKey = questionKeys.SA_PAYMENT_DETAILS;
         req.body.question = "3";
         service.getNextQuestion.mockResolvedValue({
-          data: { questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR },
+          data: { questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR },
         });
         service.submitAnswer.mockResolvedValue({});
 
@@ -71,7 +71,7 @@ describe("self-assessment-payment-question controller", () => {
         expect(service.getNextQuestion).toHaveBeenCalledWith(req);
         expect(service.getNextQuestion).toHaveBeenCalledTimes(1);
         expect(req.session.question).toEqual({
-          questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR,
+          questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR,
         });
       });
     });

--- a/tests/unit/src/app/kbv/controllers/self-assessment-tax-return-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/self-assessment-tax-return-question.test.js
@@ -1,7 +1,7 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const Controller = require("../../../../../../src/app/kbv/controllers/self-assessment-tax-return-question");
 const service = require("../../../../../../src/app/kbv/service");
-const constants = require("../../../../../../src/constants/question-keys");
+const questionKeys = require("../../../../../../src/constants/question-keys");
 jest.mock("../../../../../../src/app/kbv/service");
 
 describe("self-assessment-question controller", () => {
@@ -78,7 +78,7 @@ describe("self-assessment-question controller", () => {
 
     describe("on API success", () => {
       it("should call answer endpoint to post submitted answer", async () => {
-        const questionKey = constants.SA_INCOME_FROM_PENSIONS;
+        const questionKey = questionKeys.SA_INCOME_FROM_PENSIONS;
         req.session.question.questionKey = questionKey;
         req.body = {
           statePension: 20,
@@ -94,14 +94,14 @@ describe("self-assessment-question controller", () => {
 
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
-          constants.SA_INCOME_FROM_PENSIONS,
+          questionKeys.SA_INCOME_FROM_PENSIONS,
           "160"
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });
 
       it("should call answer endpoint to post submitted answer with short self assessment values", async () => {
-        const questionKey = constants.SA_INCOME_FROM_PENSIONS;
+        const questionKey = questionKeys.SA_INCOME_FROM_PENSIONS;
         req.session.question.questionKey = questionKey;
         req.body = {
           statePensionShort: 20,
@@ -117,17 +117,17 @@ describe("self-assessment-question controller", () => {
 
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
-          constants.SA_INCOME_FROM_PENSIONS,
+          questionKeys.SA_INCOME_FROM_PENSIONS,
           "180"
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });
 
       it("should call question endpoint to get next question and store it in session", async () => {
-        req.session.question.questionKey = constants.SA_INCOME_FROM_PENSIONS;
+        req.session.question.questionKey = questionKeys.SA_INCOME_FROM_PENSIONS;
         req.body.question = "3";
         service.getNextQuestion.mockResolvedValue({
-          data: { questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR },
+          data: { questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR },
         });
         service.submitAnswer.mockResolvedValue({});
 
@@ -136,7 +136,7 @@ describe("self-assessment-question controller", () => {
         expect(service.getNextQuestion).toHaveBeenCalledWith(req);
         expect(service.getNextQuestion).toHaveBeenCalledTimes(1);
         expect(req.session.question).toEqual({
-          questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR,
+          questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR,
         });
       });
     });

--- a/tests/unit/src/app/kbv/controllers/single-input-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/single-input-question.test.js
@@ -6,7 +6,7 @@ jest.mock("../../../../../../src/app/kbv/service");
 const presenters = require("../../../../../../src/presenters");
 jest.mock("../../../../../../src/presenters");
 const fields = require("../../../../../../src/app/kbv/fieldsHelper");
-const constants = require("../../../../../../src/constants/question-keys");
+const questionKeys = require("../../../../../../src/constants/question-keys");
 
 describe("single-input-question controller", () => {
   let controller;
@@ -109,7 +109,7 @@ describe("single-input-question controller", () => {
 
     describe("on API success", () => {
       it("should call answer endpoint to post submitted answer", async () => {
-        const questionKey = constants.RTI_PAYSLIP_NATIONAL_INSURANCE;
+        const questionKey = questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE;
         req.session.question.questionKey = questionKey;
         req.body[questionKey] = "3";
         service.getNextQuestion.mockResolvedValue({});
@@ -119,7 +119,7 @@ describe("single-input-question controller", () => {
 
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
-          constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+          questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
           "3"
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
@@ -127,10 +127,10 @@ describe("single-input-question controller", () => {
 
       it("should call question endpoint to get next question and store it in session", async () => {
         req.session.question.questionKey =
-          constants.RTI_PAYSLIP_NATIONAL_INSURANCE;
+          questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE;
         req.body.question = "3";
         service.getNextQuestion.mockResolvedValue({
-          data: { questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR },
+          data: { questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR },
         });
         service.submitAnswer.mockResolvedValue({});
 
@@ -139,12 +139,12 @@ describe("single-input-question controller", () => {
         expect(service.getNextQuestion).toHaveBeenCalledWith(req);
         expect(service.getNextQuestion).toHaveBeenCalledTimes(1);
         expect(req.session.question).toEqual({
-          questionKey: constants.RTI_P60_PAYMENT_FOR_YEAR,
+          questionKey: questionKeys.RTI_P60_PAYMENT_FOR_YEAR,
         });
       });
 
       it("should strip spaces and decimal when required", async () => {
-        const questionKey = constants.RTI_P60_EARNINGS_ABOVE_PT;
+        const questionKey = questionKeys.RTI_P60_EARNINGS_ABOVE_PT;
         req.session.question.questionKey = questionKey;
         req.body[questionKey] = " 123.45 ";
         req.form.options.fields[questionKey] = { stripDecimal: true };
@@ -165,7 +165,7 @@ describe("single-input-question controller", () => {
       });
 
       it("should strip spaces only when stripDecimal is not set to true", async () => {
-        const questionKey = constants.ITA_BANKACCOUNT;
+        const questionKey = questionKeys.ITA_BANKACCOUNT;
         req.session.question.questionKey = questionKey;
         req.body[questionKey] = " 123.45 ";
         req.form.options.fields[questionKey] = { stripDecimal: false };

--- a/tests/unit/src/presenters/question-to-content.test.js
+++ b/tests/unit/src/presenters/question-to-content.test.js
@@ -1,6 +1,6 @@
 const presenters = require("../../../../src/presenters");
 const monthsAgoToDate = require("../../../../src/utils/months-ago-to-date");
-const constants = require("../../../../src/constants/question-keys");
+const questionKeys = require("../../../../src/constants/question-keys");
 
 describe("question-to-content", () => {
   let translate;
@@ -9,7 +9,7 @@ describe("question-to-content", () => {
 
   beforeEach(() => {
     question = {
-      questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+      questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
     };
 
     translate = jest.fn();
@@ -20,7 +20,7 @@ describe("question-to-content", () => {
     presenters.questionToContent(question, translate, language);
 
     expect(translate).toHaveBeenCalledWith(
-      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+      `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
       {}
     );
   });
@@ -47,7 +47,7 @@ describe("question-to-content", () => {
       presenters.questionToContent(question, translate, language);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
         { dynamicDate }
       );
     });
@@ -56,7 +56,7 @@ describe("question-to-content", () => {
       presenters.questionToContent(question, translate, language);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
         {}
       );
     });

--- a/tests/unit/src/presenters/question-to-details.test.js
+++ b/tests/unit/src/presenters/question-to-details.test.js
@@ -1,5 +1,5 @@
 const presenters = require("../../../../src/presenters");
-const constants = require("../../../../src/constants/question-keys");
+const questionKeys = require("../../../../src/constants/question-keys");
 
 describe("question-to-details", () => {
   let translate;
@@ -7,7 +7,7 @@ describe("question-to-details", () => {
 
   beforeEach(() => {
     question = {
-      questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+      questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
     };
 
     translate = jest.fn();
@@ -17,7 +17,7 @@ describe("question-to-details", () => {
     presenters.questionToDetails(question, translate);
 
     expect(translate).toHaveBeenCalledWith(
-      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.details`
+      `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.details`
     );
   });
 

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -1,5 +1,5 @@
 const presenters = require("../../../../src/presenters");
-const constants = require("../../../../src/constants/question-keys");
+const questionKeys = require("../../../../src/constants/question-keys");
 const taxYearToRange = require("../../../../src/utils/tax-year-to-range");
 const monthsAgoToDate = require("../../../../src/utils/months-ago-to-date");
 
@@ -16,7 +16,7 @@ describe("question-to-inset", () => {
 
   beforeEach(() => {
     question = {
-      questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+      questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
       info: {
         months: "3",
       },
@@ -30,7 +30,7 @@ describe("question-to-inset", () => {
     presenters.questionToInset(question, translate, englishLanguage);
 
     expect(translate).toHaveBeenCalledWith(
-      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+      `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
       {}
     );
   });
@@ -59,7 +59,7 @@ describe("question-to-inset", () => {
       );
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         data
       );
 
@@ -82,7 +82,7 @@ describe("question-to-inset", () => {
       data.dynamicDate = welshDate;
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         data
       );
 
@@ -99,7 +99,7 @@ describe("question-to-inset", () => {
 
     it("should include tax year information in the translated inset when currentTaxYear and previousTaxYear are defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {
           currentTaxYear: "2022/23",
           previousTaxYear: "2021/22",
@@ -119,7 +119,7 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
         {
           currentYearRangeStart,
           currentYearRangeEnd,
@@ -131,7 +131,7 @@ describe("question-to-inset", () => {
 
     it("should include tax year information in the translated inset when only currentTaxYear is defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {
           currentTaxYear: "2022/23",
         },
@@ -144,7 +144,7 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {
           currentYearRangeStart,
           currentYearRangeEnd,
@@ -154,14 +154,14 @@ describe("question-to-inset", () => {
 
     it("should not include tax year information in the translated inset when currentTaxYear is not defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {},
       };
 
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {}
       );
     });
@@ -170,7 +170,7 @@ describe("question-to-inset", () => {
   describe("question-to-inset with months", () => {
     it("should include months information in the translated inset when months is defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {
           months: "3",
         },
@@ -183,21 +183,21 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         { dynamicDate }
       );
     });
 
     it("should not include months information in the translated inset when months is not defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {},
       };
 
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {}
       );
     });
@@ -206,7 +206,7 @@ describe("question-to-inset", () => {
   describe("question-to-inset key based on previousTaxYear presence", () => {
     it("should set key to include insetMultipleTaxYears when previousTaxYear is defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {
           previousTaxYear: "2021/22",
         },
@@ -215,21 +215,21 @@ describe("question-to-inset", () => {
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
         {}
       );
     });
 
     it("should set key to include inset when previousTaxYear is not defined", () => {
       question = {
-        questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+        questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
         info: {},
       };
 
       presenters.questionToInset(question, translate, englishLanguage);
 
       expect(translate).toHaveBeenCalledWith(
-        `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
+        `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         {}
       );
     });

--- a/tests/unit/src/presenters/question-to-title.test.js
+++ b/tests/unit/src/presenters/question-to-title.test.js
@@ -1,5 +1,5 @@
 const presenters = require("../../../../src/presenters");
-const constants = require("../../../../src/constants/question-keys");
+const questionKeys = require("../../../../src/constants/question-keys");
 
 describe("question-to-title", () => {
   let translate;
@@ -7,7 +7,7 @@ describe("question-to-title", () => {
 
   beforeEach(() => {
     question = {
-      questionKey: constants.RTI_PAYSLIP_NATIONAL_INSURANCE,
+      questionKey: questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE,
     };
 
     translate = jest.fn();
@@ -17,7 +17,7 @@ describe("question-to-title", () => {
     presenters.questionToTitle(question, translate);
 
     expect(translate).toHaveBeenCalledWith(
-      `pages.${constants.RTI_PAYSLIP_NATIONAL_INSURANCE}.title`
+      `pages.${questionKeys.RTI_PAYSLIP_NATIONAL_INSURANCE}.title`
     );
   });
 

--- a/tests/unit/src/utils/tax-year-to-range.test.js
+++ b/tests/unit/src/utils/tax-year-to-range.test.js
@@ -1,5 +1,5 @@
 const taxYearToRange = require("../../../../src/utils/tax-year-to-range");
-const constants = require("../../../../src/constants/question-keys");
+const questionKeys = require("../../../../src/constants/question-keys");
 
 Date.now = jest.fn(() => new Date("2024-05-01"));
 
@@ -14,7 +14,7 @@ describe("tax-year-to-range", () => {
 
   beforeEach(() => {
     question = {
-      questionKey: constants.SA_INCOME_FROM_PENSIONS,
+      questionKey: questionKeys.SA_INCOME_FROM_PENSIONS,
       info: {
         currentTaxYear: currentTaxYear,
         previousTaxYear: previousTaxYear,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Similar to the question-keys, field names and page routes/paths have been extracted into enum-like ‘constants’ files 

### Why did it change

This is so there’s only one place to change them

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6186](https://govukverify.atlassian.net/browse/PYIC-6186)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-6186]: https://govukverify.atlassian.net/browse/PYIC-6186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ