### PR TITLE
PYIC-7106 Make dynamic dates hardcoded for now

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -79,6 +79,9 @@ module.exports = {
       SELF_ASSESSMENT_PAYMENT_AMOUNT: "selfAssessmentPaymentAmount",
       ABANDON_RADIO: "abandonRadio",
     },
+    DOMAIN: {
+      DEFAULT_PAYSLIP_MONTHS_AGO: 3,
+    },
     GTM: {
       ANALYTICS_COOKIE_DOMAIN:
         process.env.ANALYTICS_COOKIE_DOMAIN || "localhost",

--- a/src/presenters/question-to-content.js
+++ b/src/presenters/question-to-content.js
@@ -1,12 +1,14 @@
+const { APP } = require("../lib/config");
 const monthsAgoToDate = require("../utils/months-ago-to-date");
 
 module.exports = function (question, translate, language) {
   const key = `pages.${question.questionKey}.content`;
   const data = {};
 
-  if (question?.info?.months) {
-    Object.assign(data, monthsAgoToDate(question?.info?.months, language));
-  }
+  Object.assign(
+    data,
+    monthsAgoToDate(APP.DOMAIN.DEFAULT_PAYSLIP_MONTHS_AGO, language)
+  );
 
   const content = translate(key, data);
 

--- a/src/presenters/question-to-inset.js
+++ b/src/presenters/question-to-inset.js
@@ -1,3 +1,4 @@
+const { APP } = require("../lib/config");
 const taxYearToRange = require("../utils/tax-year-to-range");
 const monthsAgoToDate = require("../utils/months-ago-to-date");
 
@@ -5,9 +6,10 @@ module.exports = function (question, translate, language) {
   let key = "";
   const data = {};
 
-  if (question?.info?.months) {
-    Object.assign(data, monthsAgoToDate(question?.info?.months, language));
-  }
+  Object.assign(
+    data,
+    monthsAgoToDate(APP.DOMAIN.DEFAULT_PAYSLIP_MONTHS_AGO, language)
+  );
 
   if (question?.info?.currentTaxYear) {
     Object.assign(

--- a/tests/imposter/data/questions.json
+++ b/tests/imposter/data/questions.json
@@ -2,16 +2,10 @@
   "questions": {
     "payslips": [
       {
-        "questionKey": "rti-payslip-national-insurance",
-        "info": {
-          "months": "3"
-        }
+        "questionKey": "rti-payslip-national-insurance"
       },
       {
-        "questionKey": "rti-payslip-income-tax",
-        "info": {
-          "months": "3"
-        }
+        "questionKey": "rti-payslip-income-tax"
       }
     ],
     "p60": [
@@ -76,10 +70,7 @@
         "questionKey": "ita-bankaccount"
       },
       {
-        "questionKey": "tc-amount",
-        "info": {
-          "months": "3"
-        }
+        "questionKey": "tc-amount"
       }
     ],
     "selfAssessment": [
@@ -114,10 +105,7 @@
     ],
     "abandon": [
       {
-        "questionKey": "rti-payslip-national-insurance",
-        "info": {
-          "months": "3"
-        }
+        "questionKey": "rti-payslip-national-insurance"
       }
     ]
   }

--- a/tests/unit/src/presenters/question-to-content.test.js
+++ b/tests/unit/src/presenters/question-to-content.test.js
@@ -16,12 +16,12 @@ describe("question-to-content", () => {
     language = "en";
   });
 
-  it("should call translate using questionID", () => {
+  it("should call translate using question key", () => {
     presenters.questionToContent(question, translate, language);
 
     expect(translate).toHaveBeenCalledWith(
       `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
-      {}
+      expect.any(Object)
     );
   });
 
@@ -38,26 +38,16 @@ describe("question-to-content", () => {
       expect(result).toBe("translated question content");
     });
 
-    it("should include months information in the translated content when months is defined", () => {
-      question.info = {
-        months: "3",
-      };
-
-      const { dynamicDate } = monthsAgoToDate(question?.info?.months, language);
+    it("should include months information in the translated content", () => {
+      const { dynamicDate } = monthsAgoToDate(
+        APP.DOMAIN.DEFAULT_PAYSLIP_MONTHS_AGO,
+        language
+      );
       presenters.questionToContent(question, translate, language);
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
         { dynamicDate }
-      );
-    });
-
-    it("should not include months information in the translated content when months is not defined", () => {
-      presenters.questionToContent(question, translate, language);
-
-      expect(translate).toHaveBeenCalledWith(
-        `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.content`,
-        {}
       );
     });
   });

--- a/tests/unit/src/presenters/question-to-inset.test.js
+++ b/tests/unit/src/presenters/question-to-inset.test.js
@@ -17,21 +17,17 @@ describe("question-to-inset", () => {
   beforeEach(() => {
     question = {
       questionKey: APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE,
-      info: {
-        months: "3",
-      },
     };
     data = { dynamicDate: englishDate };
     translate = jest.fn();
   });
 
-  it("should call translate using questionID without month when month is undefined", () => {
-    question.info.months = undefined;
+  it("should call translate using question key", () => {
     presenters.questionToInset(question, translate, englishLanguage);
 
     expect(translate).toHaveBeenCalledWith(
       `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-      {}
+      expect.any(Object)
     );
   });
 
@@ -120,12 +116,12 @@ describe("question-to-inset", () => {
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
-        {
+        expect.objectContaining({
           currentYearRangeStart,
           currentYearRangeEnd,
           previousYearRangeStart,
           previousYearRangeEnd,
-        }
+        })
       );
     });
 
@@ -145,10 +141,10 @@ describe("question-to-inset", () => {
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-        {
+        expect.objectContaining({
           currentYearRangeStart,
           currentYearRangeEnd,
-        }
+        })
       );
     });
 
@@ -162,22 +158,22 @@ describe("question-to-inset", () => {
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-        {}
+        expect.not.objectContaining({
+          currentYearRangeStart: expect.anything(),
+          currentYearRangeEnd: expect.anything(),
+        })
       );
     });
   });
 
   describe("question-to-inset with months", () => {
-    it("should include months information in the translated inset when months is defined", () => {
+    it("should include months information in the translated inset", () => {
       question = {
         questionKey: APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE,
-        info: {
-          months: "3",
-        },
       };
 
       const { dynamicDate } = monthsAgoToDate(
-        question.info.months,
+        APP.DOMAIN.DEFAULT_PAYSLIP_MONTHS_AGO,
         englishLanguage
       );
       presenters.questionToInset(question, translate, englishLanguage);
@@ -185,20 +181,6 @@ describe("question-to-inset", () => {
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
         { dynamicDate }
-      );
-    });
-
-    it("should not include months information in the translated inset when months is not defined", () => {
-      question = {
-        questionKey: APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE,
-        info: {},
-      };
-
-      presenters.questionToInset(question, translate, englishLanguage);
-
-      expect(translate).toHaveBeenCalledWith(
-        `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-        {}
       );
     });
   });
@@ -216,7 +198,7 @@ describe("question-to-inset", () => {
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.insetMultipleTaxYears`,
-        {}
+        expect.any(Object)
       );
     });
 
@@ -230,7 +212,7 @@ describe("question-to-inset", () => {
 
       expect(translate).toHaveBeenCalledWith(
         `pages.${APP.QUESTION_KEYS.RTI_PAYSLIP_NATIONAL_INSURANCE}.inset`,
-        {}
+        expect.any(Object)
       );
     });
   });


### PR DESCRIPTION
## Proposed changes

### What changed

Hardcode dynamic payslip dates as (today-3months) for now

### Why did it change

The HMRC API doesn't actually provide info.months for payslips questions, so as a quick fix we'll hardcode the 'use payslip dated before X' dates for now

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7106](https://govukverify.atlassian.net/browse/PYIC-7106)



[PYIC-7106]: https://govukverify.atlassian.net/browse/PYIC-7106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ