### PR TITLE
PYIC-7151: Error pages correctly render title and page content

### DIFF
--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -1,9 +1,12 @@
 error:
-  title: "Mae rhywbeth wedi mynd o'i le!"
-  content:
-    - "{{ error.message }}"
+  unrecoverable:
+    title: "Mae rhywbeth wedi mynd o'i le!"
+    h1: "Mae rhywbeth wedi mynd o'i le!"
+    content:
+      - "{{ error.message }}"
 pageNotFound:
   title: Tudalen heb ei darganfod
+  h1: Tudalen heb ei darganfod
   content:
     - Ni allwn ddod o hyd i'r dudalen rydych chi'n chwilio amdani.
     - <h2>Beth allwch chi ei wneud</h2>
@@ -12,6 +15,6 @@ pageNotFound:
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>
     - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>
-
 sessionEnded:
   title: "Sesiwn wedi dod i ben"
+  h1: "Sesiwn wedi dod i ben"

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -1,9 +1,12 @@
 error:
-  title: Sorry, there is a problem with the service
-  content:
-    - "{{ error.message }}"
+  unrecoverable:
+    title: Sorry, there is a problem with the service
+    h1: Sorry, there is a problem with the service
+    content:
+      - "{{ error.message }}"
 pageNotFound:
   title: Page not found
+  h1: Page not found
   content:
     - We cannot find the page you're looking for.
     - <h2>What you can do</h2>
@@ -12,6 +15,6 @@ pageNotFound:
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
     - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
-
 sessionEnded:
   title: Session expired
+  h1: Session expired

--- a/src/views/errors/error.njk
+++ b/src/views/errors/error.njk
@@ -1,4 +1,5 @@
 <!-- Found in common folder -->
 {% extends "unrecoverable-error.njk" %}
 
+{% set hmpoPageKey = "error.unrecoverable" %}
 {% set gtmJourney = "kbv-hmrc - unrecoverable" %}

--- a/src/views/errors/page-not-found.njk
+++ b/src/views/errors/page-not-found.njk
@@ -1,4 +1,4 @@
 {% extends "base-page.njk" %}
 
-{% set hmpoPageKey = "errors.pageNotFound" %}
+{% set hmpoPageKey = "pageNotFound" %}
 {% set gtmJourney = "kbv-hmrc - not found" %}

--- a/src/views/errors/session-ended.njk
+++ b/src/views/errors/session-ended.njk
@@ -1,4 +1,4 @@
 {% extends "base-page.njk" %}
 
-{% set hmpoPageKey = "errors.sessionEnded" %}
+{% set hmpoPageKey = "sessionEnded" %}
 {% set gtmJourney = "kbv-hmrc - error" %}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Used the correct keys in the templates and add missing locals keys

### Why did it change

Title/content for the error pages in HMRC KBVs FE not rendering content correctly, specifically error.njk, page-not-found.njk and session-ended.njk. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7151](https://govukverify.atlassian.net/browse/PYIC-7151)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


[PYIC-7151]: https://govukverify.atlassian.net/browse/PYIC-7151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ