### PR TITLE
IPS-554/kbv hmrc ecs canary stage 2

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -282,19 +282,27 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
-            - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
-      TaskDefinition: !Ref ECSServiceTaskDefinition
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
+
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"


### PR DESCRIPTION
## Proposed changes

### What changed
Stage 2 of 2 for enabling ECS Canaries (Stage 1 is [here](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-front/pull/312))

This is a fairly arbitrary change to trigger the deployment process, but removes some now-unused ECS config.

### Why did it change
Canary deployments provide extra safety measures when rolling out new application image versions

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-554

AllAtOnce rollout tested in `-dev`:

![Screenshot 2024-08-07 at 10 59 28](https://github.com/user-attachments/assets/5bdc94c9-2da9-4e51-8a66-05906fa1bdea)
![Screenshot 2024-08-07 at 11 07 55](https://github.com/user-attachments/assets/d2b735ea-fc50-42e5-86e6-ff95ce58dcc3)
