### PR TITLE
PYIC-7218 Enable Welsh toggle in all envs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -361,7 +361,7 @@ Resources:
                   !Sub "${Environment}.account.gov.uk",
                 ]
             - Name: LANGUAGE_TOGGLE_DISABLED
-              Value: true
+              Value: false
           Secrets:
             - Name: DT_TENANT
               ValueFrom: !Join


### PR DESCRIPTION
## Proposed changes

### What changed

Update template env var to enable Welsh toggle in all envs

### Why did it change

It's currently disabled in deployed envs

### Issue tracking
- [PYIC-7218](https://govukverify.atlassian.net/browse/PYIC-7218)

[PYIC-7218]: https://govukverify.atlassian.net/browse/PYIC-7218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ