### PR TITLE
LIME-1238 - Updating ECS autoscaling to have a max capacity of 60

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -565,7 +565,7 @@ Resources:
     Condition: IsProduction
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 4
+      MaxCapacity: 60
       MinCapacity: 2
       ResourceId: !Join
         - "/"


### PR DESCRIPTION
### Why did it change
- Updated auto scaling to to have a max capacity of 60 (for performance)