### PR TITLE
LIME-1248 SA payment detail userInput amended

### DIFF
--- a/src/app/kbv/controllers/self-assessment-payment-question.js
+++ b/src/app/kbv/controllers/self-assessment-payment-question.js
@@ -16,15 +16,14 @@ class SelfAssessmentPaymentQuestionController extends DateController {
 
       try {
         const userInput = JSON.stringify({
-          selfAssessmentPaymentDate: req.form.values.selfAssessmentPaymentDate,
-          selfAssessmentPaymentAmount:
-            req.form.values.selfAssessmentPaymentAmount,
+          amount: parseFloat(req.form.values.selfAssessmentPaymentAmount),
+          paymentDate: req.form.values.selfAssessmentPaymentDate,
         });
 
         await submitAnswer(
           req,
           APP.QUESTION_KEYS.SA_PAYMENT_DETAILS,
-          userInput
+          `${userInput}`
         );
 
         req.session.question = undefined;

--- a/tests/unit/src/app/kbv/controllers/self-assessment-payment-question.test.js
+++ b/tests/unit/src/app/kbv/controllers/self-assessment-payment-question.test.js
@@ -43,8 +43,12 @@ describe("self-assessment-payment-question controller", () => {
         req.session.question.questionKey = questionKey;
         req.form.values = {
           selfAssessmentPaymentDate: "2023-02-22",
-          selfAssessmentPaymentAmount: 2000.22,
+          selfAssessmentPaymentAmount: "2000.22",
         };
+        const userInput = JSON.stringify({
+          amount: parseFloat(req.form.values.selfAssessmentPaymentAmount),
+          paymentDate: req.form.values.selfAssessmentPaymentDate,
+        });
         service.getNextQuestion.mockResolvedValue({});
         service.submitAnswer.mockResolvedValue({});
 
@@ -53,7 +57,7 @@ describe("self-assessment-payment-question controller", () => {
         expect(service.submitAnswer).toHaveBeenCalledWith(
           req,
           APP.QUESTION_KEYS.SA_PAYMENT_DETAILS,
-          JSON.stringify(req.form.values)
+          userInput
         );
         expect(service.submitAnswer).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
LIME-1248 SA payment detail userInput amended

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

SA payment details userInput amended - key names amended and 'amount' value converted to number from string.

### Why did it change

To fit HMRC requirements re data type and key names of this data.

### Issue tracking

- [LIME-1248](https://govukverify.atlassian.net/browse/LIME-1248)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

### Other considerations

Related PR has already been merged for the https://github.com/govuk-one-login/ipv-third-party-stubs/pull/238 to remove a troublesome space from in front of the amount for user AL000000S to ensure third-party-stub test users are now in keeping with the format expected by HMRC. This has been confirmed by testing user journeys with the minor third-party-stub change and this FE change.


[LIME-1248]: https://govukverify.atlassian.net/browse/LIME-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ