### PR TITLE
PYIC-7357: Remove maxlength attributes from text boxes

### DIFF
--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -38,6 +38,9 @@ module.exports = {
   [APP.QUESTION_KEYS.ITA_BANKACCOUNT]: {
     type: "text",
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
+    // Remove maxlength attribute that gets automatically added for exactlength validators
+    // https://github.com/HMPO/hmpo-components/blob/01473508284e1d06ebc72585f970f25f17fba49d/components/hmpo-text/macro.njk#L32
+    attributes: { "maxlength": undefined },
   },
   [APP.QUESTION_KEYS.RTI_P60_EARNINGS_ABOVE_PT]:
     validateRequiredAmountWithPounds,
@@ -86,6 +89,18 @@ module.exports = {
   [APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE]: {
     type: "date",
     validate: ["required", "date", { type: "before", arguments: [] }],
+  },
+  // By default date controls have maxlength attributes applied to their inputs
+  // We override that with this configuration. Note that these fields also need
+  // to be specified in any step using SELF_ASSESSMENT_PAYMENT_DATE
+  [APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_DAY]: {
+    attributes: { maxlength: undefined },
+  },
+  [APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_MONTH]: {
+    attributes: { maxlength: undefined },
+  },
+  [APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_YEAR]: {
+    attributes: { maxlength: undefined },
   },
   [APP.FIELDS.SELF_ASSESSMENT_PAYMENT_AMOUNT]:
     validateRequiredAmountWithPoundsAndPence,

--- a/src/app/kbv/fields.js
+++ b/src/app/kbv/fields.js
@@ -40,7 +40,7 @@ module.exports = {
     validate: ["required", "numeric", { type: "exactlength", arguments: [4] }],
     // Remove maxlength attribute that gets automatically added for exactlength validators
     // https://github.com/HMPO/hmpo-components/blob/01473508284e1d06ebc72585f970f25f17fba49d/components/hmpo-text/macro.njk#L32
-    attributes: { "maxlength": undefined },
+    attributes: { maxlength: undefined },
   },
   [APP.QUESTION_KEYS.RTI_P60_EARNINGS_ABOVE_PT]:
     validateRequiredAmountWithPounds,

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -163,6 +163,11 @@ module.exports = {
       template: "self-assessment-payment",
       fields: [
         APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE,
+        // We need to explicitly specify the sub-fields of the date component
+        // so that the config we specify in fields.js is picked up and used.
+        APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_DAY,
+        APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_MONTH,
+        APP.FIELDS.SELF_ASSESSMENT_PAYMENT_DATE_YEAR,
         APP.FIELDS.SELF_ASSESSMENT_PAYMENT_AMOUNT,
       ],
       controller: selfAssessmentPaymentQuestionController,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,6 +1,6 @@
 require("dotenv").config();
 
-// These are the suffixes that the HMPO framework adds to the ID of a date
+// These are the suffixes that the GOVUK Design system adds to the ID of a date
 // control to generate the IDs of the text inputs.
 const HMPO_SUFFIX_DAY = "-day";
 const HMPO_SUFFIX_MONTH = "-month";

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -82,9 +82,12 @@ module.exports = {
       JOB_SEEKERS_ALLOWANCE_SHORT: "jobSeekersAllowanceShort",
       STATE_PENSION_AND_BENEFITS_SHORT: "statePensionAndBenefitsShort",
       SELF_ASSESSMENT_PAYMENT_DATE: "selfAssessmentPaymentDate",
-      SELF_ASSESSMENT_PAYMENT_DATE_DAY: "selfAssessmentPaymentDate" + HMPO_SUFFIX_DAY,
-      SELF_ASSESSMENT_PAYMENT_DATE_MONTH: "selfAssessmentPaymentDate" + HMPO_SUFFIX_MONTH,
-      SELF_ASSESSMENT_PAYMENT_DATE_YEAR: "selfAssessmentPaymentDate" + HMPO_SUFFIX_YEAR,
+      SELF_ASSESSMENT_PAYMENT_DATE_DAY:
+        "selfAssessmentPaymentDate" + HMPO_SUFFIX_DAY,
+      SELF_ASSESSMENT_PAYMENT_DATE_MONTH:
+        "selfAssessmentPaymentDate" + HMPO_SUFFIX_MONTH,
+      SELF_ASSESSMENT_PAYMENT_DATE_YEAR:
+        "selfAssessmentPaymentDate" + HMPO_SUFFIX_YEAR,
       SELF_ASSESSMENT_PAYMENT_AMOUNT: "selfAssessmentPaymentAmount",
       ABANDON_RADIO: "abandonRadio",
     },

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,5 +1,11 @@
 require("dotenv").config();
 
+// These are the suffixes that the HMPO framework adds to the ID of a date
+// control to generate the IDs of the text inputs.
+const HMPO_SUFFIX_DAY = "-day";
+const HMPO_SUFFIX_MONTH = "-month";
+const HMPO_SUFFIX_YEAR = "-year";
+
 module.exports = {
   API: {
     BASE_URL: process.env.API_BASE_URL || "http://localhost:8080",
@@ -76,6 +82,9 @@ module.exports = {
       JOB_SEEKERS_ALLOWANCE_SHORT: "jobSeekersAllowanceShort",
       STATE_PENSION_AND_BENEFITS_SHORT: "statePensionAndBenefitsShort",
       SELF_ASSESSMENT_PAYMENT_DATE: "selfAssessmentPaymentDate",
+      SELF_ASSESSMENT_PAYMENT_DATE_DAY: "selfAssessmentPaymentDate" + HMPO_SUFFIX_DAY,
+      SELF_ASSESSMENT_PAYMENT_DATE_MONTH: "selfAssessmentPaymentDate" + HMPO_SUFFIX_MONTH,
+      SELF_ASSESSMENT_PAYMENT_DATE_YEAR: "selfAssessmentPaymentDate" + HMPO_SUFFIX_YEAR,
       SELF_ASSESSMENT_PAYMENT_AMOUNT: "selfAssessmentPaymentAmount",
       ABANDON_RADIO: "abandonRadio",
     },

--- a/tests/browser/step_definitions/enter-4-digits-bank-account-tax-credits.js
+++ b/tests/browser/step_definitions/enter-4-digits-bank-account-tax-credits.js
@@ -19,7 +19,7 @@ When(
     const singleInputQuestionPage = new Enter4DigitsBankAccountTaxCredits(
       this.page
     );
-    await singleInputQuestionPage.answer("1234.45");
+    await singleInputQuestionPage.answer("1234");
     await singleInputQuestionPage.continue();
   }
 );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove `maxlength` attributes from text inputs

### Why did it change

Accessibility

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7357](https://govukverify.atlassian.net/browse/PYIC-7357)


[PYIC-7357]: https://govukverify.atlassian.net/browse/PYIC-7357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ