### PR TITLE
LIME-1238 - Updating ECS autoscaling to use step scaling instead of t…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -646,143 +646,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref APIGWAccessLogsGroup
 
-  # ECS Autoscaling
-  # The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.
-  # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
-
-  ECSAutoScalingTarget:
-    Condition: IsPerformance
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Properties:
-      MaxCapacity: 60
-      MinCapacity: 2
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
-      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-
-  ECSAutoScalingPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: ECSAutoScalingPolicy
-      PolicyType: TargetTrackingScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      TargetTrackingScalingPolicyConfiguration:
-        PredefinedMetricSpecification:
-          PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 60
-        ScaleInCooldown: 420
-        ScaleOutCooldown: 60
-
-  StepScaleInPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: StepScalingInPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 420
-        StepAdjustments:
-          - MetricIntervalUpperBound: -40
-            ScalingAdjustment: -50
-
-  StepScaleOutPolicy:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::ApplicationAutoScaling::ScalingPolicy
-    Properties:
-      PolicyName: StepScalingOutPolicy
-      PolicyType: StepScaling
-      ResourceId: !Join
-        - "/"
-        - - "service"
-          - !Ref EcsCluster
-          - !GetAtt EcsService.Name
-      ScalableDimension: ecs:service:DesiredCount
-      ServiceNamespace: ecs
-      StepScalingPolicyConfiguration:
-        AdjustmentType: PercentChangeInCapacity
-        Cooldown: 120
-        MinAdjustmentMagnitude: 5
-        StepAdjustments:
-          - MetricIntervalLowerBound: 20
-            MetricIntervalUpperBound: 30
-            ScalingAdjustment: 200
-          - MetricIntervalLowerBound: 30
-            MetricIntervalUpperBound: 35
-            ScalingAdjustment: 300
-          - MetricIntervalLowerBound: 35
-            ScalingAdjustment: 500
-
-  StepScaleOutAlarm:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref StepScaleOutPolicy
-      AlarmDescription: "HmrcKbvFrontClusterOver60PercentCPU"
-      ComparisonOperator: "GreaterThanThreshold"
-      DatapointsToAlarm: "2"
-      Dimensions:
-        - Name: ClusterName
-          Value: !Ref EcsCluster
-        - Name: ServiceName
-          Value: !GetAtt EcsService.Name
-      Unit: "Percent"
-      EvaluationPeriods: "2"
-      MetricName: "CPUUtilization"
-      Namespace: "AWS/ECS"
-      Statistic: "Average"
-      Period: "60"
-      Threshold: "60"
-
-  StepScaleInAlarm:
-    Condition: IsPerformance
-    DependsOn: ECSAutoScalingTarget
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref StepScaleInPolicy
-      AlarmDescription: "HmrcKbvFrontClusterUnder60PercentCPU"
-      ComparisonOperator: "LessThanThreshold"
-      DatapointsToAlarm: "5"
-      Dimensions:
-        - Name: ClusterName
-          Value: !Ref EcsCluster
-        - Name: ServiceName
-          Value: !GetAtt EcsService.Name
-      Unit: "Percent"
-      EvaluationPeriods: "5"
-      MetricName: "CPUUtilization"
-      Namespace: "AWS/ECS"
-      Statistic: "Average"
-      Period: "60"
-      Threshold: "60"
-
   SessionsTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -802,6 +665,146 @@ Resources:
         # checkov:skip=CKV_AWS_119: Implement Customer Managed Keys in PYIC-1391
         SSEEnabled: true
         SSEType: KMS
+
+  # ECS Autoscaling
+  EcsAutoScalingTarget:
+    Condition: IsPerformance
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 60
+      MinCapacity: 2
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref EcsCluster
+          - !GetAtt EcsService.Name
+      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  EcsStepScaleOutPolicy:
+    Condition: IsPerformance
+    DependsOn: EcsAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: EcsStepScalingOutPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref EcsCluster
+          - !GetAtt EcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown:
+          60 # The policy will continue to respond to additional alarm breaches,
+          # even while a scaling activity is in progress. This means Application
+          # Auto Scaling will evaluate all alarm breaches as they occur.
+          # A cooldown period is used to protect against over-scaling due to
+          # multiple alarm breaches occurring in rapid succession.
+        MinAdjustmentMagnitude: 5
+        StepAdjustments:
+          - MetricIntervalUpperBound: 20 #90%
+            ScalingAdjustment:
+              100 # Scale by 100% of containers if the metric is breached
+              # between -infinity and 20 points above threshold
+          - MetricIntervalLowerBound: 20 #80%
+            MetricIntervalUpperBound: 30 #90%
+            ScalingAdjustment:
+              200 # Scale by 200% of containers if the metric is breached
+              # between 80% and 90% utilisation.
+          - MetricIntervalLowerBound: 30 #90%
+            MetricIntervalUpperBound: 35 #95%
+            ScalingAdjustment:
+              300 # Scale by 300% of containers if the metric is breached
+              # between 90% and 95% utilisation.
+          - MetricIntervalLowerBound: 35 #95%
+            ScalingAdjustment:
+              500 # Scale by 500% of containers if the metric is breached
+              # between 95% or above
+              # Note: CPU can scale greater than 100% in a burst mode
+              # on Fargate, so leave the upper bound open
+
+  EcsStepScaleInPolicy:
+    Condition: IsPerformance
+    DependsOn: EcsAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: EcsStepScalingInPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - "/"
+        - - "service"
+          - !Ref EcsCluster
+          - !GetAtt EcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown:
+          30 # The policy will continue to respond to additional alarm breaches,
+          # even while a scaling activity is in progress. This means Application
+          # Auto Scaling will evaluate all alarm breaches as they occur.
+          # A cooldown period is used to protect against over-scaling due to
+          # multiple alarm breaches occurring in rapid succession.
+        StepAdjustments:
+          - MetricIntervalLowerBound: -20 #20%
+            ScalingAdjustment:
+              -50 # Scale down 50% of containers if the metric is breached
+              # between -infinity and 20 points above threshold.
+          - MetricIntervalLowerBound: -20 #20%
+            MetricIntervalUpperBound: 0 #60%
+            ScalingAdjustment: -10
+
+  EcsStepScaleOutAlarm:
+    Condition: IsPerformance
+    DependsOn: EcsAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref EcsStepScaleOutPolicy
+      AlarmDescription: "EcsClusterOver60PercentCPU"
+      ComparisonOperator: "GreaterThanThreshold"
+      DatapointsToAlarm: "2"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref EcsCluster
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "2"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "60"
+
+  EcsStepScaleInAlarm:
+    Condition: IsPerformance
+    DependsOn: EcsAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref EcsStepScaleInPolicy
+      AlarmDescription: "EcsClusterUnder60PercentCPU"
+      ComparisonOperator: "LessThanThreshold"
+      DatapointsToAlarm: "5"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref EcsCluster
+        - Name: ServiceName
+          Value: !GetAtt EcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "5"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "60"
 
   NoTaskCountAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
### What changed

- Removed outdated Target Scaling policies
- Added Step Scaling In and Out policies with defined CPU utilisation percentages for scaling in and out under different load
- Added Alarms for when scaling occurs

### Why did it change

To keep EcsAutoScaling policies inline with ADR 140 - https://github.com/govuk-one-login/architecture/blob/main/adr/0140-fargate-scaling.md