### PR TITLE
IPS-1132: Add linting

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -37,7 +37,7 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       - name: "Push image and template"
         uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0

--- a/.github/workflows/pre-merge-to-dev.yml
+++ b/.github/workflows/pre-merge-to-dev.yml
@@ -37,7 +37,7 @@ jobs:
           password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       - name: "Push image and template"
         uses: govuk-one-login/devplatform-upload-action-ecr@v1.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
         exclude: package-lock.json
@@ -10,7 +10,7 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.8
+    rev: v1.15.2
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -280,7 +280,10 @@ Resources:
           - CODE_DEPLOY
           - ECS
       EnableECSManagedTags: false
-      HealthCheckGracePeriodSeconds: 60
+      HealthCheckGracePeriodSeconds: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - 60
       LaunchType: FARGATE
       LoadBalancers: !If
         - UseCanaryDeployment


### PR DESCRIPTION
### What changed
- Add SAM validate lint on pre and post merge checks

The following change was required to pass the new linting steps:

- Create condition for `HealthCheckGracePeriodSeconds` (this Property is only used if canaries are disabled ie if the service is using a load balancer and not managed by CodeDeploy). This was to fix `E3056 | ECS service using HealthCheckGracePeriodSeconds must also have LoadBalancers specified` [E3056](https://github.com/aws-cloudformation/cfn-lint/blob/main/src/cfnlint/rules/resources/ecs/ServiceHealthCheckGracePeriodSeconds.py) See the docs at:
  - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html
  - https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance

### Why did it change
- Code Quality control

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [IPS-1132](https://govukverify.atlassian.net/browse/IPS-1132)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1118]: https://govukverify.atlassian.net/browse/LIME-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IPS-1132]: https://govukverify.atlassian.net/browse/IPS-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ