### PR TITLE
refactor(mock): ports abandon script to Groovy.

### DIFF
--- a/tests/imposter/private-api-config.yaml
+++ b/tests/imposter/private-api-config.yaml
@@ -206,13 +206,15 @@ resources:
     steps:
       # short-circuit when it's the 'abandon' journey
       - type: script
+        lang: groovy
         code: |
-          if (/questions-abandon.+/.test(context.request.headers['session-id'])) {
-            var deniedResponse = {
+          if (context.request.headers['session-id'] ==~ /questions-abandon.+/) {
+            def deniedResponse = [
               redirect_uri: "http://example.net",
-              oauth_error: { error_description: "access-denied", error: "access_denied" }
-            };
-            respond().withStatusCode(500).withContent(JSON.stringify(deniedResponse));
+              oauth_error: [ error_description: "access-denied", error: "access_denied" ]
+            ]
+            def serializer = new groovy.json.JsonOutput()
+            respond().withStatusCode(500).withContent(serializer.toJson(deniedResponse))
           }
     response:
       template: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### Background

The mock endpoint for `/authorization` has a short-circuit condition if it detects that the session ID matches a particular 'abandon' pattern.

### What changed

Ports the mock code for the `/authorization` abandon condition from JavaScript to Groovy.

### Why did it change

This condition was written in JavaScript, but the remainder of the mock's scripts are written in Groovy.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- None

## Checklists

### Environment variables or secrets

None

### Other considerations

- ~Update [README](./blob/main/README.md) with any new instructions or tasks~ N/A

### Test evidence

✅ Abandon condition should match
✅ Returns valid JSON

```shell
$ curl http://localhost:8080/authorization -H 'session-id: questions-abandon-SEPARATOR-foo'

{"redirect_uri":"http://example.net","oauth_error":{"error_description":"access-denied","error":"access_denied"}}
```

✅ Abandon condition should not match
✅ Default response should be returned

```shell
$ curl  localhost:8080/authorization -H 'session-id: questions-payslips-SEPARATOR-foo'
{
  "authorizationCode": {
    "value":"auth-code-bd74eac6-980b-4abb-9a3d-795ca455602c"
  },
  "state":"sT@t3",
  "redirect_uri":"http://example.net"
}
```