### PR TITLE
LIME-1316 Align health check with ADR140

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -206,8 +206,8 @@ Resources:
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
-      HealthCheckTimeoutSeconds: 14
-      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 2
+      HealthCheckIntervalSeconds: 5
       HealthyThresholdCount: 2
       Matcher:
         HttpCode: 200


### PR DESCRIPTION
## Proposed changes

### What changed

Changed health check values for HealthCheckTimeoutSeconds and HealthCheckIntervalSeconds

### Why did it change

To match recommended values on ADR140

### Issue tracking

- [LIME-1316](https://govukverify.atlassian.net/browse/LIME-1316)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1316]: https://govukverify.atlassian.net/browse/LIME-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ