### PR TITLE
LIME-1465 updates ECS configuration for decom

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -65,22 +65,42 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       ga4Disabled: "false"
       uaDisabled: "false"
+      minECSCount: 1
+      maxECSCount: 1
+      cpu: 256
+      memory: 512
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       ga4Disabled: "false"
       uaDisabled: "false"
+      minECSCount: 0
+      maxECSCount: 0
+      cpu: 256
+      memory: 512
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       ga4Disabled: "false"
       uaDisabled: "false"
+      minECSCount: 0
+      maxECSCount: 0
+      cpu: 256
+      memory: 512
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       ga4Disabled: "true"
       uaDisabled: "false"
+      minECSCount: 0
+      maxECSCount: 0
+      cpu: 256
+      memory: 512
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       ga4Disabled: "true"
       uaDisabled: "false"
+      minECSCount: 0
+      maxECSCount: 0
+      cpu: 256
+      memory: 512
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -203,7 +223,7 @@ Resources:
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckEnabled: TRUE
+      HealthCheckEnabled: true
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
       HealthCheckTimeoutSeconds: 2
@@ -223,7 +243,7 @@ Resources:
   LoadBalancerListenerGreenTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
-      HealthCheckEnabled: TRUE
+      HealthCheckEnabled: true
       HealthCheckProtocol: HTTP
       HealthCheckPath: /healthcheck
       Matcher:
@@ -422,9 +442,9 @@ Resources:
               awslogs-group: !Ref ECSAccessLogsGroup
               awslogs-region: !Sub ${AWS::Region}
               awslogs-stream-prefix: !Sub ${AWS::StackName}-${Environment}
-      Cpu: "256"
+      Cpu: !FindInMap [EnvironmentConfiguration, !Ref Environment, cpu]
       ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
-      Memory: "512"
+      Memory: !FindInMap [EnvironmentConfiguration, !Ref Environment, memory]
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - FARGATE
@@ -677,11 +697,12 @@ Resources:
 
   # ECS Autoscaling
   ECSAutoScalingTarget:
-    Condition: IsPerformance
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: 1
-      MinCapacity: 1
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
       ResourceId: !Join
         - "/"
         - - "service"
@@ -692,7 +713,6 @@ Resources:
       ServiceNamespace: ecs
 
   EcsStepScaleOutPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -734,7 +754,6 @@ Resources:
             # on Fargate, so leave the upper bound open
 
   EcsStepScaleInPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Template.yaml updated as part of decommissioning of HMRC KBV to reduce maintenance costs. 
ECS Autoscaling min and max set to one in dev to still allow for testing and set to 0 in all other environments. CPU and memory set to minimum possible for dev and 0 for all other environments. Unnecessary alarms disabled.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1465](https://govukverify.atlassian.net/browse/LIME-1465)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Evidence

- **Showing what will happen in dev**
I added the dev environment to the 'IsPerformance' condition and deployed to dev to test my changes. 
&nbsp;
**- Evidence min and max container value is working:**
<img width="1728" alt="Screenshot 2025-01-14 at 16 55 53" src="https://github.com/user-attachments/assets/f14af687-de8b-46f8-8543-659d49dc2461" />
<img width="1728" alt="Screenshot 2025-01-14 at 16 56 15" src="https://github.com/user-attachments/assets/4ba4b016-8fc0-4892-ba97-1e158b5d2bc3" />

&nbsp;
- **Evidence CPU and memory amended:**
post changes:
<img width="1728" alt="Screenshot 2025-01-14 at 16 32 01" src="https://github.com/user-attachments/assets/79f2f7be-0f3a-4689-8709-9d94852b2dd7" />
&nbsp;
&nbsp;
pre-changes:
<img width="1728" alt="Screenshot 2025-01-14 at 16 32 33" src="https://github.com/user-attachments/assets/16f2c291-9125-4faf-945b-b6536bdeb58b" />

&nbsp;
- **One container running:**
<img width="1728" alt="Screenshot 2025-01-14 at 16 34 10" src="https://github.com/user-attachments/assets/9fca722d-e5a1-4f6b-8742-a3f92f395a49" />

-------------------------------------------------------------------------------------------------------------

&nbsp;
- **Showing what will happen in higher environments which will have no containers**
Setting container limit to 0 in dev and deploying to dev resulted in a 503 error being returned when trying to access the service:
![image](https://github.com/user-attachments/assets/3fd44b4e-d39d-4731-af8e-fad2423c9cf9)
This shows that the build, staging, integration and production environments will have the same result as their container limits will remain set to 0. Dev will have a container limit of 1 to allow for deployment to dev for testing. 

[LIME-1465]: https://govukverify.atlassian.net/browse/LIME-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ