### PR TITLE
Update to  exclude the origin load balancer from the regional FMS policy

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -219,6 +219,9 @@ Resources:
           - Key: access_logs.s3.prefix
             Value: !Sub ${AWS::StackName}-${Environment}
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"


### PR DESCRIPTION
This is protected by a specific WAF for CloudFront

## Proposed changes

Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### What changed
Added tags

### Why did it change
to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1407
