### PR TITLE
IPS-1416: Associate CloadkingOriginWebACLArn with the load balancer

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -664,6 +664,12 @@ Resources:
           "responseLatency":"$context.responseLatency"
           }
 
+    CloudFrontWAFv2ACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn: !Ref LoadBalancer
+      WebACLArn: !ImportValue cfront-origin-distrib-CloakingOriginWebACLArn
+
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
- Associate CloackingOriginWebACLArn with the load balancer

### What changed
- Associate CloadkingOriginWebACLArn with the load balancer

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- While doing FMS migrations, it came into our notice that there is no association been with Load balancer. This does not affect the service as hmrckbv is still not live. But It was recommended from secops to add this association.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1416](https://govukverify.atlassian.net/browse/IPS-1416)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
